### PR TITLE
Add synchronizations before magma_free calls

### DIFF
--- a/sparse/control/magma_zfree.cpp
+++ b/sparse/control/magma_zfree.cpp
@@ -23,6 +23,8 @@
     -------
 
     Free the memory of a magma_z_matrix.
+    Note, this routine performs a magma_queue_sync on the queue passed
+    to it prior to freeing any memory.
 
 
     Arguments
@@ -187,6 +189,7 @@ magma_zmfree(
     }
 
     if ( A->memory_location == Magma_DEV ) {
+	magma_queue_sync( queue );
         if (A->storage_type == Magma_ELL || A->storage_type == Magma_ELLPACKT) {
             if (A->ownership) {
                 if ( magma_free( A->dval ) != MAGMA_SUCCESS ) {
@@ -444,7 +447,8 @@ magma_zmfree(
     -------
 
     Free a preconditioner.
-
+    Note, this routine performs a magma_queue_sync on the queue passed
+    to it prior to freeing any memory.
 
     Arguments
     ---------
@@ -465,6 +469,7 @@ magma_zprecondfree(
     magma_z_preconditioner *precond_par,
     magma_queue_t queue ){
 
+    magma_queue_sync( queue );
     if ( precond_par->d.val != NULL ) {
         magma_free( precond_par->d.val );
         precond_par->d.val = NULL;

--- a/sparse/src/zsyisai.cpp
+++ b/sparse/src/zsyisai.cpp
@@ -264,6 +264,7 @@ magma_zicisaisetup(
     // magma_z_mvisu( precond->UD, queue ); 
      
 cleanup:
+    magma_queue_sync( queue );
     magma_free( sizes_d );
     magma_free_cpu( sizes_h );
     magma_free( locations_d );

--- a/src/dshposv_gmres_gpu.cpp
+++ b/src/dshposv_gmres_gpu.cpp
@@ -438,6 +438,7 @@ fallback:
     }
 
 cleanup:
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     return *info;
 }

--- a/src/dxgesv_gmres_gpu.cpp
+++ b/src/dxgesv_gmres_gpu.cpp
@@ -823,6 +823,7 @@ fallback:
     MAGMA_UNUSED( cntl );
 
 cleanup:
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dA_dprec );
     magma_free( dA_sprec );

--- a/src/xhsgetrf_gpu.cpp
+++ b/src/xhsgetrf_gpu.cpp
@@ -537,6 +537,8 @@ magma_xhsgetrf_gpu(
     printf("from inside xhsgetrf here is c_gpu_nan %d c_gpu_inf %d\n",(int)c_gpu_nan, (int)c_gpu_inf);
 #endif
 cleanup:
+    magma_queue_sync( queues[0] );
+    magma_queue_sync( queues[1] );
     magma_queue_destroy( queues[0] );
     magma_queue_destroy( queues[1] );
     magma_event_destroy( event[0] );

--- a/src/zcgeqrsv_gpu.cpp
+++ b/src/zcgeqrsv_gpu.cpp
@@ -390,6 +390,7 @@ fallback:
     }
 
 cleanup:
+    magma_queue_sync( queue );
     magma_free( dworks );
     magma_free( dworkd );
     magma_free_cpu( hworks );

--- a/src/zgbsv_batched.cpp
+++ b/src/zgbsv_batched.cpp
@@ -401,6 +401,7 @@ magma_zgbsv_batched(
         info_array,
         device_work, lwork, batchCount, queue);
 
+    magma_queue_sync( queue );
     magma_free( device_work );
     return arginfo;
 }
@@ -463,6 +464,7 @@ magma_zgbsv_batched_strided(
         dB, lddb, strideB, info_array,
         device_work, lwork, batchCount, queue);
 
+    magma_queue_sync( queue );
     magma_free( device_work );
     return arginfo;
 

--- a/src/zgbsv_gpu.cpp
+++ b/src/zgbsv_gpu.cpp
@@ -134,6 +134,7 @@ magma_zgbsv_native(
         dB, lddb,
         info, device_work, lwork, queue);
 
+    magma_queue_sync( queue );
     magma_free(device_work);
     magma_queue_destroy( queue );
 

--- a/src/zgbtrf_batched.cpp
+++ b/src/zgbtrf_batched.cpp
@@ -452,6 +452,7 @@ magma_zgbtrf_batched(
         dipiv_array, info_array,
         device_work, lwork, batchCount, queue);
 
+    magma_queue_sync( queue );
     magma_free(device_work);
     return arginfo;
 }

--- a/src/zgelqf_gpu.cpp
+++ b/src/zgelqf_gpu.cpp
@@ -178,6 +178,7 @@ magma_zgelqf_gpu(
     }
 
 cleanup:
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     
     return *info;

--- a/src/zgeqp3_gpu.cpp
+++ b/src/zgeqp3_gpu.cpp
@@ -265,7 +265,7 @@ magma_zgeqp3_gpu(
                              &tau[j], &rwork[j], &rwork[n+j], dwork );
         }*/
     }
-
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     
     magma_free( df );

--- a/src/zgeqrf_batched.cpp
+++ b/src/zgeqrf_batched.cpp
@@ -241,6 +241,7 @@ magma_zgeqrf_batched(
                 info_array, device_work, device_lwork,
                 batchCount, queue);
 
+    magma_queue_sync( queue );
     if(device_work != NULL) magma_free(device_work);
     return arginfo;
 }

--- a/src/zgerbt_batched.cpp
+++ b/src/zgerbt_batched.cpp
@@ -173,6 +173,7 @@ magma_zgerbt_batched(
     /* Compute U^T.b on the GPU*/
     magmablas_zprbt_mtv_batched(n, nrhs, du, dB_array, lddb, batchCount, queue);
 
+    magma_queue_sync( queue );
     magma_free( du );
     magma_free( dv );
 

--- a/src/zgerbt_gpu.cpp
+++ b/src/zgerbt_gpu.cpp
@@ -162,6 +162,7 @@ magma_zgerbt_gpu(
     /* Compute U^T * b on the GPU*/
     magmablas_zprbt_mtv(n, nrhs, dU, dB, lddb, queue);
 
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dU );
     magma_free( dV );

--- a/src/zgetrf_panel_nopiv_batched.cpp
+++ b/src/zgetrf_panel_nopiv_batched.cpp
@@ -161,6 +161,7 @@ magma_zgetrf_recpanel_nopiv_batched(
         if (arginfo != 0) return arginfo;
     }
 
+    magma_queue_sync( queue );
     magma_free(dA_displ);
     return 0;
 }

--- a/src/zheevr_gpu.cpp
+++ b/src/zheevr_gpu.cpp
@@ -560,6 +560,7 @@ magma_zheevr_gpu(
     rwork[1] = magma_dmake_lwork( lrwmin );
     iwork[1] = liwmin;
 
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dwork );
 

--- a/src/zheevx_gpu.cpp
+++ b/src/zheevx_gpu.cpp
@@ -468,6 +468,7 @@ magma_zheevx_gpu(
     /* Set WORK[0] to optimal complex workspace size. */
     work[1] = magma_zmake_lwork( lopt );
 
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dwork );
 

--- a/src/zlauum.cpp
+++ b/src/zlauum.cpp
@@ -217,6 +217,8 @@ magma_zlauum(
         }
     }
     
+    magma_queue_sync( queues[0] );
+    magma_queue_sync( queues[1] );
     magma_queue_destroy( queues[0] );
     magma_queue_destroy( queues[1] );
 

--- a/src/zpotrf_panel_vbatched.cpp
+++ b/src/zpotrf_panel_vbatched.cpp
@@ -55,6 +55,7 @@ magma_zpotrf_panel_vbatched(
                                            0, batchCount,
                                            max_n-nb, nb, queue );
     }
+    magma_queue_sync( queue );
     magma_free( n_minus_ib );
     return arginfo;
 }

--- a/src/zsytrf_nopiv_gpu.cpp
+++ b/src/zsytrf_nopiv_gpu.cpp
@@ -252,6 +252,8 @@ magma_zsytrf_nopiv_gpu(
     }
     
     trace_finalize( "zhetrf.svg","trace.css" );
+    magma_queue_sync( queues[0] );
+    magma_queue_sync( queues[1] );
     magma_queue_destroy( queues[0] );
     magma_queue_destroy( queues[1] );
     magma_event_destroy( event );

--- a/src/zunmql2_gpu.cpp
+++ b/src/zunmql2_gpu.cpp
@@ -255,6 +255,7 @@ magma_zunmql2_gpu(
     }
 
 cleanup:
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dwork );
 

--- a/src/zunmqr2_gpu.cpp
+++ b/src/zunmqr2_gpu.cpp
@@ -257,6 +257,7 @@ magma_zunmqr2_gpu(
     }
 
 cleanup:
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     magma_free( dwork );
 

--- a/src/zunmqr_gpu.cpp
+++ b/src/zunmqr_gpu.cpp
@@ -326,14 +326,12 @@ magma_zunmqr_gpu(
         magma_zsetmatrix( mi, ni, hC, mi, dC(ic, jc), lddc, queue );
     }
     
-    // TODO sync. For cases Q*C and C*Q^T, last call is magma_zlarfb_gpu,
-    // which is async magma_gemm calls, so zunmqr can be unfinished.
-
     // TODO: zgeqrs_gpu ASSUMES that hwork contains the last block of A and C.
     // That needs to be fixed, but until then, don't modify hwork[0] here.
     // In LAPACK: On exit, if INFO = 0, HWORK[0] returns the optimal LWORK.
     //hwork[0] = magma_zmake_lwork( lwkopt );
-    
+   
+    magma_queue_sync( queue );
     magma_queue_destroy( queue );
     
     return *info;


### PR DESCRIPTION
This PR adds some explicit synchronization points before calling `magma_free` on memory allocated inside MAGMA routines. This is due to a difference in SYCL, where there is no implicit synchronization forced by freeing GPU memory.
This can result in memory being freed before a kernel is completed. (See https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_memory_deallocation_functions for `sycl::free`: "The memory is freed without waiting for commands operating on it to be completed. If commands that use this memory are in-progress or are enqueued the behavior is undefined.")

For the sparse portion, `magma_zmfree` to free a sparse matrix object takes a queue, unlike `magma_free`, so I added a sync inside `magma_zmfree` itself prior to the `magma_free` calls within.

A possible discussion here is whether we want to add a queue parameter to allocate/free memory for the dense portion as well, in which case we could add the sync inside and revert most of the changes in this PR.