### PR TITLE
a quick fix to build issues against cuda 12.6

### DIFF
--- a/magmablas/zgbtf2_kernels.cu
+++ b/magmablas/zgbtf2_kernels.cu
@@ -12,6 +12,10 @@
 
 #include "magma_internal.h"
 #if   defined(MAGMA_HAVE_CUDA)
+#if CUDA_VERSION >= 12060
+#undef max
+#undef min
+#endif
 #include <cooperative_groups.h>
 namespace cg = cooperative_groups;
 #elif defined(MAGMA_HAVE_HIP)


### PR DESCRIPTION
This is a quick fix for the building error encountered under cuda-12.6, which is basically due to conflicting definitions of `max` and `min` macros. 