### PR TITLE
add hip::device target to the magma library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,24 +502,25 @@ else()
         CUDA::cublas
         CUDA::cusparse
         magma_nvcc_flags
-	)
+        )
     else()
       find_package( hipBLAS )
       if (hipBLAS_FOUND)
-	message( STATUS "Found rocBLAS ${rocBLAS_VERSION}" )
+        message( STATUS "Found rocBLAS ${rocBLAS_VERSION}" )
       endif()
       find_package( hipSPARSE )
       if (hipSPARSE_FOUND)
-	message( STATUS "Found rocSPARSE ${rocSPARSE_VERSION}" )
+        message( STATUS "Found rocSPARSE ${rocSPARSE_VERSION}" )
       endif()
       add_library( magma ${libmagma_all} )
       target_link_libraries( magma
-	hip::host
+        hip::host
         ${blas_fix}
         ${LAPACK_LIBRARIES}
-	roc::hipblas
-	roc::hipsparse
-	)
+        hip::device
+        roc::hipblas
+        roc::hipsparse
+        )
     endif()
 
     if (USE_FORTRAN)


### PR DESCRIPTION
I don't see why `hip::device` should be added to `magma_sparse`, but not `magma`.

We had to patch this in Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/magma/-/commit/cbecba83c22d010ad33b9a5b9be476ddb214d59b#36eca9771d4db6fcdca0078c00246a7ddbbcad30