### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -55,7 +55,7 @@ PROJECT_NAME           = MAGMA
 # control system is used.
 
 # MAGMA
-PROJECT_NUMBER         = 2.8.0
+PROJECT_NUMBER         = 2.9.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/documentation-sparse.txt
+++ b/docs/documentation-sparse.txt
@@ -3,7 +3,9 @@
 ********************************************************************************
 @page MAGMA-sparse Sparse Overview
 
-**IMPORTANT NOTE:** As of December 2024, the MAGMA-sparse package is considered
+IMPORTANT NOTE
+==============
+As of December 2024, the MAGMA-sparse package is considered
 to be "Legacy Support Mode" ONLY, meaning the MAGMA-sparse component is not under active
 development. Many sparse routines have been deprecated with MAGMA 2.9.0. Users are
 encouraged to consider switching to the Ginkgo library (https://ginkgo-project.github.io)

--- a/docs/documentation.txt
+++ b/docs/documentation.txt
@@ -437,24 +437,21 @@ routines call several computational routines to solve the entire problem.
 Here, curly braces { } group similar routines.
 Starred * routines are not yet implemented in MAGMA.
 
-Name                                                                                |  Description
------------                                                                         |  -----------
-: **Triangular factorizations** :                                                   |  **Description**
-\ref magma_getrf "getrf", \ref magma_potrf "potrf", \ref magma_hetrf "hetrf"        |  triangular factorization (LU, Cholesky, Indefinite)
-\ref magma_getrs "getrs", \ref magma_potrs "potrs", \ref magma_hetrs "hetrs"        |  triangular forward and back solve
-\ref magma_getri "getri", \ref magma_potri "potri"                                  |  triangular inverse
-\ref magma_getf2 "getf2", \ref magma_potf2 "potf2"                                  |  triangular panel factorization (BLAS-2)
-. **Orthogonal factorizations**                                                     |  **Description**
-ge{\ref magma_geqrf "qrf", \ref magma_geqlf "qlf",  \ref magma_gelqf "lqf",  rqf*}  |  QR, QL, LQ, RQ factorization
-\ref magma_geqp3 "geqp3"                                                            |  QR with column pivoting (BLAS-3)
-or{\ref magma_unmqr "mqr", \ref magma_unmql "mql",  \ref magma_unmlq "mlq",  mrq*}  |  multiply by Q after factorization (real)
-un{\ref magma_unmqr "mqr", \ref magma_unmql "mql",  \ref magma_unmlq "mlq",  mrq*}  |  multiply by Q after factorization (complex)
-or{\ref magma_ungqr "gqr", gql*, glq*, grq*}                                        |  generate Q after factorization (real)
-un{\ref magma_ungqr "gqr", gql*, glq*, grq*}                                        |  generate Q after factorization (complex)
-. **Eigenvalue & SVD**                                                              |  **Description**
-\ref magma_gehrd "gehrd"                                                            |  Hessenberg  reduction (in geev)
-\ref magma_hetrd "sytrd/hetrd"                                                      |  tridiagonal reduction (in syev, heev)
-\ref magma_gebrd "gebrd"                                                            |  bidiagonal  reduction (in gesvd)
+|           | Name                            |  Description                        |
+|:---------:|:--------------------------------|:------------------------------------|
+| Triangular factorizations | \ref magma_getrf "getrf", \ref magma_potrf "potrf", \ref magma_hetrf "hetrf"        |  triangular factorization (LU, Cholesky, Indefinite) |
+| ^ | \ref magma_getrs "getrs", \ref magma_potrs "potrs", \ref magma_hetrs "hetrs"        |  triangular forward and back solve |
+| ^ | \ref magma_getri "getri", \ref magma_potri "potri"                                  |  triangular inverse |
+| ^ | \ref magma_getf2 "getf2", \ref magma_potf2 "potf2"                                  |  triangular panel factorization (BLAS-2) |
+| Orthogonal factorizations | ge{\ref magma_geqrf "qrf", \ref magma_geqlf "qlf",  \ref magma_gelqf "lqf",  rqf*}  |  QR, QL, LQ, RQ factorization |
+| ^ | \ref magma_geqp3 "geqp3"                                                            |  QR with column pivoting (BLAS-3) |
+| ^ | or{\ref magma_unmqr "mqr", \ref magma_unmql "mql",  \ref magma_unmlq "mlq",  mrq*}  |  multiply by Q after factorization (real) |
+| ^ | un{\ref magma_unmqr "mqr", \ref magma_unmql "mql",  \ref magma_unmlq "mlq",  mrq*}  |  multiply by Q after factorization (complex) |
+| ^ | or{\ref magma_ungqr "gqr", gql*, glq*, grq*}                                        |  generate Q after factorization (real) |
+| ^ | un{\ref magma_ungqr "gqr", gql*, glq*, grq*}                                        |  generate Q after factorization (complex) |
+| Eigenvalue & SVD          | \ref magma_gehrd "gehrd"                                    |  Hessenberg  reduction (in geev) |
+| ^ | \ref magma_hetrd "sytrd/hetrd"                                                      |  tridiagonal reduction (in syev, heev) |
+| ^ | \ref magma_gebrd "gebrd"                                                            |  bidiagonal  reduction (in gesvd) |
 
 There are many other computational routines that are mostly internal to
 MAGMA and LAPACK, and not commonly called by end users.


### PR DESCRIPTION
After @mgates3's overhaul of the Doxygen in #26, I noticed two spots where the formatting didn't render the way we want, at least when I build the documentation on my laptop. The main one is the "Computational routines" table: 

Before (what's currently in the main branch) -- note the stray colons and periods in the sub-header text:
<img width="1300" alt="table-before" src="https://github.com/user-attachments/assets/42ab9b54-5991-4ad3-942f-4abce53dcf65" />

After (this branch):
<img width="1302" alt="table-after" src="https://github.com/user-attachments/assets/22d620c0-7713-4fd6-9da8-ba66e801b60c" />

I also updated the project number to 2.9.0, assuming this will be basically the last thing before we do the release.
