### PR TITLE
Adding variable batch size support for nonpivoted getrf

### DIFF
--- a/include/magma_zvbatched.h
+++ b/include/magma_zvbatched.h
@@ -152,6 +152,75 @@ magma_zlaswp_right_rowparallel_vbatched(
         magma_int_t **pivinfo_array, magma_int_t pivinfo_i,
         magma_int_t batchCount, magma_queue_t queue);
 
+magma_int_t magma_zscal_zgeru_nopiv_vbatched(
+    magma_int_t max_M, magma_int_t max_N,
+    magma_int_t *M, magma_int_t *N,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
+    double *dtol_array, magma_int_t *info_array, magma_int_t step, magma_int_t gbstep,
+    magma_int_t batchCount, magma_queue_t queue);
+
+magma_int_t
+magma_zgetf2_nopiv_fused_sm_vbatched(
+    magma_int_t max_M, magma_int_t max_N, magma_int_t max_minMN, magma_int_t max_MxN,
+    magma_int_t* m, magma_int_t* n,
+    magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array, magma_int_t* info_array, magma_int_t gbstep,
+    magma_int_t nthreads, magma_int_t check_launch_only,
+    magma_int_t batchCount, magma_queue_t queue);
+
+magma_int_t
+magma_zgetf2_nopiv_fused_vbatched(
+    magma_int_t max_M, magma_int_t max_N,
+    magma_int_t max_minMN, magma_int_t max_MxN,
+    magma_int_t* M, magma_int_t* N,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array, magma_int_t *info_array, magma_int_t batchCount,
+    magma_queue_t queue);
+
+magma_int_t
+magma_zgetf2_nopiv_vbatched(
+    magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
+    magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
+    double *dtol_array, magma_int_t *info_array,
+    magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue);
+
+magma_int_t
+magma_zgetrf_nopiv_recpanel_vbatched(
+    magma_int_t* m, magma_int_t* n, magma_int_t* minmn,
+    magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn,
+    magma_int_t max_mxn, magma_int_t min_recpnb,
+    magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array,
+    magma_int_t *info_array, magma_int_t gbstep,
+    magma_int_t batchCount,  magma_queue_t queue);
+    
+magma_int_t
+magma_zgetrf_nopiv_vbatched_max_nocheck(
+        magma_int_t* m, magma_int_t* n, magma_int_t* minmn,
+        magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+        magma_int_t nb, magma_int_t recnb,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double* dtol_array,
+        magma_int_t *info_array, magma_int_t batchCount,
+        magma_queue_t queue);
+
+magma_int_t
+magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+        magma_int_t* m, magma_int_t* n,
+        magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, magma_int_t *info_array,
+        void* work, magma_int_t* lwork,
+        magma_int_t batchCount, magma_queue_t queue);
+
+magma_int_t
+magma_zgetrf_nopiv_vbatched(
+        magma_int_t* m, magma_int_t* n,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, magma_int_t *info_array,
+        magma_int_t batchCount, magma_queue_t queue);
+
 magma_int_t
 magma_zpotrf_lpout_vbatched(
     magma_uplo_t uplo, magma_int_t *n, magma_int_t max_n,

--- a/include/magma_zvbatched.h
+++ b/include/magma_zvbatched.h
@@ -156,7 +156,7 @@ magma_int_t magma_zscal_zgeru_nopiv_vbatched(
     magma_int_t max_M, magma_int_t max_N,
     magma_int_t *M, magma_int_t *N,
     magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
-    double *dtol_array, magma_int_t *info_array, magma_int_t step, magma_int_t gbstep,
+    double *dtol_array, double eps, magma_int_t *info_array, magma_int_t step, magma_int_t gbstep,
     magma_int_t batchCount, magma_queue_t queue);
 
 magma_int_t
@@ -164,7 +164,7 @@ magma_zgetf2_nopiv_fused_sm_vbatched(
     magma_int_t max_M, magma_int_t max_N, magma_int_t max_minMN, magma_int_t max_MxN,
     magma_int_t* m, magma_int_t* n,
     magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
-    double* dtol_array, magma_int_t* info_array, magma_int_t gbstep,
+    double* dtol_array, double eps, magma_int_t* info_array, magma_int_t gbstep,
     magma_int_t nthreads, magma_int_t check_launch_only,
     magma_int_t batchCount, magma_queue_t queue);
 
@@ -174,7 +174,7 @@ magma_zgetf2_nopiv_fused_vbatched(
     magma_int_t max_minMN, magma_int_t max_MxN,
     magma_int_t* M, magma_int_t* N,
     magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
-    double* dtol_array, magma_int_t *info_array, magma_int_t batchCount,
+    double* dtol_array, double eps, magma_int_t *info_array, magma_int_t batchCount,
     magma_queue_t queue);
 
 magma_int_t
@@ -182,7 +182,7 @@ magma_zgetf2_nopiv_vbatched(
     magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
     magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
     magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
-    double *dtol_array, magma_int_t *info_array,
+    double *dtol_array, double eps, magma_int_t *info_array,
     magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue);
 
 magma_int_t
@@ -191,7 +191,7 @@ magma_zgetrf_nopiv_recpanel_vbatched(
     magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn,
     magma_int_t max_mxn, magma_int_t min_recpnb,
     magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
-    double* dtol_array,
+    double* dtol_array, double eps,
     magma_int_t *info_array, magma_int_t gbstep,
     magma_int_t batchCount,  magma_queue_t queue);
     
@@ -201,7 +201,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
         magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
         magma_int_t nb, magma_int_t recnb,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double* dtol_array,
+        double* dtol_array, double eps,
         magma_int_t *info_array, magma_int_t batchCount,
         magma_queue_t queue);
 
@@ -210,7 +210,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck_work(
         magma_int_t* m, magma_int_t* n,
         magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double *dtol_array, magma_int_t *info_array,
+        double *dtol_array, double eps, magma_int_t *info_array,
         void* work, magma_int_t* lwork,
         magma_int_t batchCount, magma_queue_t queue);
 
@@ -218,7 +218,14 @@ magma_int_t
 magma_zgetrf_nopiv_vbatched(
         magma_int_t* m, magma_int_t* n,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double *dtol_array, magma_int_t *info_array,
+        magma_int_t *info_array,
+        magma_int_t batchCount, magma_queue_t queue);
+
+magma_int_t
+magma_zgetrf_nopiv_expert_vbatched(
+        magma_int_t* m, magma_int_t* n,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, double eps, magma_int_t *info_array,
         magma_int_t batchCount, magma_queue_t queue);
 
 magma_int_t

--- a/magmablas/Makefile.src
+++ b/magmablas/Makefile.src
@@ -22,6 +22,7 @@ hdr += \
 	$(cdir)/zlarfg_devicesfunc.cuh		\
 	$(cdir)/ztrsv_template_device.cuh	\
 	$(cdir)/zgetf2_devicefunc.cuh		\
+	$(cdir)/zgetf2_nopiv_devicefunc.cuh		\
 	$(cdir)/zlaswp_device.cuh		\
 	$(cdir)/zgeqr2_batched_fused.cuh	\
 	$(cdir)/zlarf_batched_fused.cuh	\
@@ -221,6 +222,7 @@ libmagma_src += \
 
 libmagma_src += \
 	$(cdir)/zgetf2_kernels_var.cu	\
+	$(cdir)/zgetf2_nopiv_kernels_var.cu	\
 	$(cdir)/zlaswp_vbatched.cu		\
 	$(cdir)/zpotf2_kernels_var.cu	\
 
@@ -358,6 +360,11 @@ $(cdir)/sgetf2_kernels_var.$(o_ext): $(cdir)/sgetf2_devicefunc.cuh
 $(cdir)/dgetf2_kernels_var.$(o_ext): $(cdir)/dgetf2_devicefunc.cuh
 $(cdir)/cgetf2_kernels_var.$(o_ext): $(cdir)/cgetf2_devicefunc.cuh
 $(cdir)/zgetf2_kernels_var.$(o_ext): $(cdir)/zgetf2_devicefunc.cuh
+
+$(cdir)/sgetf2_nopiv_kernels_var.$(o_ext): $(cdir)/sgetf2_nopiv_devicefunc.cuh
+$(cdir)/dgetf2_nopiv_kernels_var.$(o_ext): $(cdir)/dgetf2_nopiv_devicefunc.cuh
+$(cdir)/cgetf2_nopiv_kernels_var.$(o_ext): $(cdir)/cgetf2_nopiv_devicefunc.cuh
+$(cdir)/zgetf2_nopiv_kernels_var.$(o_ext): $(cdir)/zgetf2_nopiv_devicefunc.cuh
 
 $(cdir)/ztrsv_batched.$(o_ext): $(cdir)/ztrsv_template_device.cuh $(cdir)/gemv_template_device.cuh $(cdir)/gemm_template_device_defs.cuh
 $(cdir)/ctrsv_batched.$(o_ext): $(cdir)/ctrsv_template_device.cuh $(cdir)/gemv_template_device.cuh $(cdir)/gemm_template_device_defs.cuh

--- a/magmablas/zgetf2_nopiv_devicefunc.cuh
+++ b/magmablas/zgetf2_nopiv_devicefunc.cuh
@@ -1,0 +1,75 @@
+/*
+   -- MAGMA (version 2.0) --
+   Univ. of Tennessee, Knoxville
+   Univ. of California, Berkeley
+   Univ. of Colorado, Denver
+   @date
+
+
+   @author Ahmad Abdelfattah
+   @author Azzam Haidar
+
+   @precisions normal z -> s d c
+ */
+
+
+#ifndef MAGMABLAS_ZGETF2_NOPIV_DEVICES_Z_H
+#define MAGMABLAS_ZGETF2_NOPIV_DEVICES_Z_H
+
+/******************************************************************************/
+template<int WIDTH>
+static __device__ __inline__
+void
+zgetf2_nopiv_fused_device( int m, int minmn, magmaDoubleComplex rA[WIDTH], double tol,
+                     magmaDoubleComplex* swork, int &linfo, int gbstep, int &rowid)
+{
+    const int tx = threadIdx.x;
+    const int ty = threadIdx.y;
+
+    magmaDoubleComplex reg       = MAGMA_Z_ZERO;
+    double rx_abs_max = MAGMA_D_ZERO;
+
+    magmaDoubleComplex *sx = (magmaDoubleComplex*)(swork);
+    double* dsx = (double*)(sx + blockDim.y * WIDTH);
+    sx    += ty * WIDTH;
+    rowid = tx;
+
+    #pragma unroll
+    for(int i = 0; i < WIDTH; i++){
+        dsx[ rowid ] = fabs(MAGMA_Z_REAL( rA[i] )) + fabs(MAGMA_Z_IMAG( rA[i] ));
+        __syncthreads();
+        rx_abs_max = dsx[i];
+        if(rx_abs_max < tol)
+        {
+            if(tx == i)
+            {
+                int sign = (MAGMA_Z_REAL( rA[i] ) < 0 ? -1 : 1);
+                rA[i] = MAGMA_Z_MAKE(sign * tol, 0);
+            }
+            rx_abs_max = tol;
+            linfo++;
+            __syncthreads();
+        }
+
+        if( rowid == i ) {
+            #pragma unroll
+            for(int j = 0; j < WIDTH; j++){
+                sx[j] = rA[j];
+            }
+        }
+        __syncthreads();
+
+        reg = (rx_abs_max == MAGMA_D_ZERO ) ? MAGMA_Z_ONE : MAGMA_Z_DIV(MAGMA_Z_ONE, sx[i] );
+        // scal and ger
+        if( rowid > i ){
+            rA[i] *= reg;
+            #pragma unroll
+            for(int j = i+1; j < WIDTH; j++){
+                rA[j] -= rA[i] * sx[j];
+            }
+        }
+    }
+}
+
+
+#endif // MAGMABLAS_ZGETF2_NOPIV_DEVICES_Z_H

--- a/magmablas/zgetf2_nopiv_kernels_var.cu
+++ b/magmablas/zgetf2_nopiv_kernels_var.cu
@@ -1,0 +1,459 @@
+/*
+    -- MAGMA (version 2.0) --
+       Univ. of Tennessee, Knoxville
+       Univ. of California, Berkeley
+       Univ. of Colorado, Denver
+       @date
+
+       @author Ahmad Abdelfattah
+
+       @precisions normal z -> s d c
+*/
+
+#include "magma_internal.h"
+#include "batched_kernel_param.h"
+#include "magma_templates.h"
+#include "shuffle.cuh"
+
+#define PRECISION_z
+#include "zgetf2_devicefunc.cuh"
+#include "zgetf2_nopiv_devicefunc.cuh"
+
+/******************************************************************************/
+__global__
+void zscal_zgeru_nopiv_tinypivots_kernel_vbatched(
+        int max_m, int max_n,
+        magma_int_t *M, magma_int_t *N,
+        magmaDoubleComplex **dA_array, int Ai, int Aj, magma_int_t *ldda,
+        double *dtol_array, double eps, magma_int_t *info_array, magma_int_t batchCount)
+{
+    const int batchid = threadIdx.x + blockIdx.x * blockDim.x;
+    if(batchid >= batchCount) return;
+
+    int my_M    = (int)M[batchid];
+    int my_N    = (int)N[batchid];
+    int my_ldda = (int)ldda[batchid];
+    double tol  = (dtol_array ? dtol_array[batchid] : eps);
+
+    if( my_M <= Ai || my_N <= Aj ) return;
+
+    magmaDoubleComplex* dA = dA_array[batchid] + Aj * my_ldda + Ai;
+    magma_int_t *info = &info_array[batchid];
+
+    magmaDoubleComplex rA = dA[0];
+    double val = fabs(MAGMA_Z_REAL( rA )) + fabs(MAGMA_Z_IMAG( rA ));
+
+    if(val < tol)
+    {
+        int sign = (MAGMA_Z_REAL( rA ) < 0 ? -1 : 1);
+        rA = MAGMA_Z_MAKE(sign * tol, 0);
+        dA[0] = rA;
+        *info++;
+    }
+}
+
+/******************************************************************************/
+extern "C"
+magma_int_t magma_zscal_zgeru_nopiv_vbatched(
+        magma_int_t max_M, magma_int_t max_N,
+        magma_int_t *M, magma_int_t *N,
+        magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
+        double *dtol_array, magma_int_t *info_array, magma_int_t step, magma_int_t gbstep,
+        magma_int_t batchCount, magma_queue_t queue)
+{
+    const int tbx = 256;
+    dim3 threads(tbx, 1, 1);
+    double eps = lapackf77_dlamch("Epsilon");
+
+    // First check the pivots and replace the tiny ones by the operation's tolerance
+    dim3 grid(magma_ceildiv(batchCount, tbx), 1, 1);
+    zscal_zgeru_nopiv_tinypivots_kernel_vbatched<<<grid, threads, 0, queue->cuda_stream()>>>
+    (max_M, max_N, M, N, dA_array, Ai, Aj, ldda, dtol_array, eps, info_array, batchCount);
+
+    // Now call the regular scal and geru routine
+    // TODO: the current implementation takes the info array but does not alter it 
+    // so it's safe to use this function. If that changes in the future, then this 
+    // function should be replaced with one that does not alter the info array 
+    return magma_zscal_zgeru_vbatched(
+        max_M, max_N, M, N, dA_array, Ai, Aj, ldda, info_array, step, gbstep,
+        batchCount, queue
+    );
+}
+
+/******************************************************************************/
+#define dA(i,j)              dA[(j) * my_ldda + (i)]
+#define sA(i,j)              sA[(j) * my_M + (i)]
+
+__global__
+void
+zgetf2_nopiv_fused_sm_kernel_vbatched(
+        int max_M, int max_N, int max_minMN, int max_MxN,
+        magma_int_t *M, magma_int_t *N,
+        magmaDoubleComplex** dA_array, int Ai, int Aj, magma_int_t* ldda,
+        double* dtol_array, double eps, magma_int_t *info_array,  int gbstep, int batchCount )
+{
+    extern __shared__ magmaDoubleComplex zdata[];
+    const int tx      = threadIdx.x;
+    const int ty      = threadIdx.y;
+    const int ntx     = blockDim.x;
+    const int batchid = (blockIdx.x * blockDim.y) + ty;
+    if(batchid >= batchCount) return;
+
+    // read data of assigned problem
+    int my_M         = (int)M[batchid];
+    int my_N         = (int)N[batchid];
+    int my_ldda      = (int)ldda[batchid];
+    double tol       = (dtol_array ? dtol_array[batchid] : eps);
+    int my_minmn     = min(my_M, my_N);
+    magmaDoubleComplex* dA = dA_array[batchid] + Aj * my_ldda + Ai;
+    magma_int_t* info      = &info_array[batchid];
+
+    // check offsets
+    if( my_M <= Ai || my_N <= Aj ) return;
+    my_M     -= Ai;
+    my_N     -= Aj;
+    my_M      = min(my_M, max_M);
+    my_N      = min(my_N, max_N);
+    my_minmn  = min(my_M, my_N);
+
+    magmaDoubleComplex *sA = (magmaDoubleComplex*)(zdata);
+    magmaDoubleComplex reg  = MAGMA_Z_ZERO;
+    magmaDoubleComplex rTmp = MAGMA_Z_ZERO;
+
+    int linfo = (gbstep == 0) ? 0 : *info;
+    double rx_abs_max = MAGMA_D_ZERO;
+
+    // read
+    for(int j = 0; j < my_N; j++){
+        for(int i = tx; i < my_M; i+=ntx) {
+            sA(i,j) = dA(i,j);
+        }
+    }
+    __syncthreads();
+
+    for(int j = 0; j < my_minmn; j++){
+        rx_abs_max = fabs(MAGMA_Z_REAL( sA(j,j) )) + fabs(MAGMA_Z_IMAG( sA(j,j) ));
+        __syncthreads();
+
+        if(rx_abs_max < tol)
+        {
+            int sign = (MAGMA_Z_REAL( sA(j,j) ) < 0 ? -1 : 1);
+            sA(j,j) = MAGMA_Z_MAKE(sign * tol, 0);
+            rx_abs_max = tol;
+            linfo++;
+            __syncthreads();
+        }
+
+        reg = (rx_abs_max == MAGMA_D_ZERO) ? MAGMA_Z_ONE : MAGMA_Z_DIV( MAGMA_Z_ONE, sA(j,j) );
+        for(int i = (tx+j+1); i < my_M; i+=ntx) {
+            rTmp    = reg * sA(i,j);
+            sA(i,j) = rTmp;
+            for(int jj = j+1; jj < my_N; jj++) {
+                sA(i,jj) -= rTmp * sA(j,jj);
+            }
+        }
+        __syncthreads();
+    }
+
+    if(tx == 0){
+        (*info) = (magma_int_t)( linfo );
+    }
+
+    // write A
+    for(int j = 0; j < my_N; j++) {
+        for(int i = tx; i < my_M; i+=ntx) {
+            dA(i,j) = sA(i,j);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+extern "C" magma_int_t
+magma_zgetf2_nopiv_fused_sm_vbatched(
+    magma_int_t max_M, magma_int_t max_N, magma_int_t max_minMN, magma_int_t max_MxN,
+    magma_int_t* m, magma_int_t* n,
+    magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array, magma_int_t* info_array, magma_int_t gbstep,
+    magma_int_t nthreads, magma_int_t check_launch_only,
+    magma_int_t batchCount, magma_queue_t queue )
+{
+    magma_int_t arginfo = 0;
+    magma_device_t device;
+    magma_getdevice( &device );
+
+    nthreads = nthreads <= 0 ? (max_M/2) : nthreads;
+    #ifdef MAGMA_HAVE_CUDA
+    nthreads = magma_roundup(nthreads, 32);
+    #else
+    nthreads = magma_roundup(nthreads, 64);
+    #endif
+    nthreads = min(nthreads, 1024);
+
+    // in a variable-size setting, setting ntcol > 1 may lead to
+    // kernel deadlocks due to different thread-groups calling
+    // syncthreads at different points
+    const magma_int_t ntcol = 1;
+    int         shmem = ( max_MxN   * sizeof(magmaDoubleComplex) );
+    shmem            *= ntcol;
+    magma_int_t gridx = magma_ceildiv(batchCount, ntcol);
+    dim3 grid(gridx, 1, 1);
+    dim3 threads( nthreads, ntcol, 1);
+
+    // get max. dynamic shared memory on the GPU
+    int nthreads_max, shmem_max = 0;
+    cudaDeviceGetAttribute (&nthreads_max, cudaDevAttrMaxThreadsPerBlock, device);
+    #if CUDA_VERSION >= 9000
+    cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+    if (shmem <= shmem_max) {
+        cudaFuncSetAttribute(zgetf2_nopiv_fused_sm_kernel_vbatched, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
+    }
+    #else
+    cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlock, device);
+    #endif    // CUDA_VERSION >= 9000
+
+    magma_int_t total_threads = nthreads * ntcol;
+    if ( total_threads > nthreads_max || shmem > shmem_max ) {
+        //printf("error: kernel %s requires too many threads or too much shared memory\n", __func__);
+        arginfo = -100;
+        return arginfo;
+    }
+
+    if( check_launch_only == 1 ) return arginfo;
+
+    double eps = lapackf77_dlamch("Epsilon");
+    
+    void *kernel_args[] = {&max_M, &max_N, &max_minMN, &max_MxN, &m, &n, &dA_array, &Ai, &Aj, &ldda, &dtol_array, &eps, &info_array, &gbstep, &batchCount};
+    cudaError_t e = cudaLaunchKernel((void*)zgetf2_nopiv_fused_sm_kernel_vbatched, grid, threads, kernel_args, shmem, queue->cuda_stream());
+    if( e != cudaSuccess ) {
+        //printf("error in %s : failed to launch kernel %s\n", __func__, cudaGetErrorString(e));
+        arginfo = -100;
+    }
+
+    return arginfo;
+}
+
+
+/******************************************************************************/
+#define SLDA(n)              ( (((n)+1)%4) == 0 ? (n) : (n+1) )
+#define ibatch    (0)
+template<int max_N>
+__global__ void
+zgetf2_nopiv_fused_kernel_vbatched(
+        int max_M,
+        magma_int_t* M, magma_int_t* N,
+        magmaDoubleComplex** dA_array, int Ai, int Aj, magma_int_t* ldda,
+        double* dtol_array, double eps, 
+        magma_int_t* info_array, int batchCount)
+{
+    extern __shared__ magmaDoubleComplex data[];
+    const int tx = threadIdx.x;
+    const int batchid = blockIdx.x * blockDim.y + threadIdx.y;
+    if(batchid >= batchCount)return;
+
+    // read data of assigned problem
+    int my_M         = (int)M[batchid];
+    int my_N         = (int)N[batchid];
+    int my_ldda      = (int)ldda[batchid];
+    double tol       = (dtol_array ? dtol_array[batchid] : eps);
+    int my_minmn     = (int)min(my_M, my_N);
+    magmaDoubleComplex* dA = dA_array[batchid] + Aj * my_ldda + Ai;
+
+    // check offsets
+    if( my_M <= Ai || my_N <= Aj ) return;
+    // (my_M, my_N) based on (M,N) and offsets (Ai,Aj)
+    my_M     -= Ai;
+    my_N     -= Aj;
+
+    // now compare (my_M,my_N) with max_M, max_N
+    my_M = min(my_M, max_M);
+    my_N = min(my_N, max_N);
+    my_minmn  = min(my_M, my_N);
+
+    int rowid, gbstep = Aj;
+    int linfo   = (gbstep == 0) ? 0 : info_array[batchid];
+    const int slda = SLDA(max_M);
+    magmaDoubleComplex  rA[max_N] = {MAGMA_Z_ZERO};
+
+    // init sA into identity
+    magmaDoubleComplex* sA = (magmaDoubleComplex*)data;
+    #pragma unroll
+    for(int j = 0; j < max_N; j++) {
+        sA[j * slda + tx] = (j == tx) ? MAGMA_Z_ONE : MAGMA_Z_ZERO;
+    }
+    __syncthreads();
+
+    // read A into sm then mv to reg
+    if(tx < my_M) {
+        for(int j = 0; j < my_N; j++) {
+            sA[j * slda + tx] = dA[j * my_ldda + tx];
+        }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for(int j = 0; j < max_N; j++){
+        rA[j] = sA[ j * slda + tx ];
+    }
+    __syncthreads();
+
+    zgetf2_nopiv_fused_device<max_N>(
+             max_M, my_minmn, rA,
+             tol,
+             sA, linfo, gbstep, rowid);
+
+    __syncthreads();
+
+    // write to shared
+    #pragma unroll
+    for(int j = 0; j < max_N; j++){
+        sA[ j * slda + rowid ] = rA[j];
+    }
+    __syncthreads();
+
+    if(tx == 0){
+        info_array[batchid] = (magma_int_t)( linfo );
+    }
+
+    // write to global
+    if(tx < my_M) {
+        for(int j = 0; j < my_N; j++) {
+            dA[j * my_ldda + tx] = sA[j * slda + tx];
+        }
+    }
+}
+
+/******************************************************************************/
+template<int max_N>
+static magma_int_t
+magma_zgetf2_nopiv_fused_kernel_driver_vbatched(
+    magma_int_t max_M,
+    magma_int_t* M, magma_int_t* N,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array, magma_int_t *info_array, magma_int_t batchCount, magma_queue_t queue )
+{
+    magma_int_t arginfo = 0;
+    magma_device_t device;
+    magma_getdevice( &device );
+
+    // this kernel works only if m <= n for every matrix
+    // this is only for short-wide sizes that fit in shared memory
+    // should not affect performance for other shapes
+    max_M = max(max_M, max_N);
+
+    int ntcol = 1;
+    int shmem = 0, shmem_1 = 0, shmem_2 = 0;
+    shmem_1 += max_N * sizeof(magmaDoubleComplex);
+    shmem_1 += max_M * sizeof(double);
+
+    shmem_2 += SLDA(max_M) * max_N * sizeof(magmaDoubleComplex);
+
+    shmem  = max(shmem_1, shmem_2);
+    shmem *= ntcol;
+
+    dim3 grid(magma_ceildiv(batchCount,ntcol), 1, 1);
+    dim3 threads(max_M, ntcol, 1);
+
+    // get max. dynamic shared memory on the GPU
+    int nthreads_max, nthreads = max_M * ntcol, shmem_max = 0;
+    cudaDeviceGetAttribute (&nthreads_max, cudaDevAttrMaxThreadsPerBlock, device);
+    #if CUDA_VERSION >= 9000
+    cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+    if (shmem <= shmem_max) {
+        cudaFuncSetAttribute(zgetf2_nopiv_fused_kernel_vbatched<max_N>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem);
+    }
+    #else
+    cudaDeviceGetAttribute (&shmem_max, cudaDevAttrMaxSharedMemoryPerBlock, device);
+    #endif    // CUDA_VERSION >= 9000
+
+    magma_int_t total_threads = nthreads * ntcol;
+    if ( total_threads > nthreads_max || shmem > shmem_max ) {
+        //printf("error: kernel %s requires too many threads or too much shared memory\n", __func__);
+        arginfo = -100;
+        return arginfo;
+    }
+    
+    double eps = lapackf77_dlamch("Epsilon");
+
+    void *kernel_args[] = {&max_M, &M, &N, &dA_array, &Ai, &Aj, &ldda, &dtol_array, &eps, &info_array, &batchCount};
+    cudaError_t e = cudaLaunchKernel((void*)zgetf2_nopiv_fused_kernel_vbatched<max_N>, grid, threads, kernel_args, shmem, queue->cuda_stream());
+    if( e != cudaSuccess ) {
+        //printf("error in %s : failed to launch kernel %s\n", __func__, cudaGetErrorString(e));
+        arginfo = -100;
+    }
+
+    return arginfo;
+}
+
+/******************************************************************************/
+extern "C" magma_int_t
+magma_zgetf2_nopiv_fused_vbatched(
+    magma_int_t max_M, magma_int_t max_N,
+    magma_int_t max_minMN, magma_int_t max_MxN,
+    magma_int_t* M, magma_int_t* N,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array, magma_int_t *info_array, magma_int_t batchCount,
+    magma_queue_t queue)
+{
+    //printf("max_M = %d, max_N = %d\n", max_M, max_N);
+
+    magma_int_t info = 0;
+    if(max_M < 0 ) {
+        info = -1;
+    }
+    else if(max_N < 0){
+        info = -2;
+    }
+
+    if(info < 0) return info;
+
+
+    info = -1;
+    switch(max_N) {
+        case  1: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 1>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  2: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 2>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  3: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 3>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  4: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 4>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  5: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 5>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  6: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 6>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  7: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 7>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  8: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 8>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case  9: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched< 9>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 10: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<10>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 11: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<11>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 12: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<12>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 13: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<13>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 14: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<14>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 15: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<15>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 16: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<16>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 17: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<17>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 18: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<18>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 19: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<19>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 20: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<20>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 21: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<21>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 22: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<22>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 23: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<23>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 24: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<24>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 25: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<25>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 26: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<26>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 27: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<27>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 28: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<28>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 29: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<29>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 30: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<30>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 31: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<31>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        case 32: info = magma_zgetf2_nopiv_fused_kernel_driver_vbatched<32>(max_M, M, N, dA_array, Ai, Aj, ldda, dtol_array, info_array, batchCount, queue); break;
+        default: ;
+    }
+
+    if( info != 0 ) {
+        // try sm version
+        magma_int_t sm_nthreads = max(32, max_M / 2);
+        sm_nthreads = magma_roundup(sm_nthreads, 32);
+        info = magma_zgetf2_nopiv_fused_sm_vbatched(
+                    max_M, max_N, max_minMN, max_MxN,
+                    M, N, dA_array, Ai, Aj, ldda,
+                    dtol_array,
+                    info_array, Aj, sm_nthreads, 0, batchCount, queue );
+    }
+
+    return info;
+}

--- a/magmablas/zgetf2_nopiv_kernels_var.cu
+++ b/magmablas/zgetf2_nopiv_kernels_var.cu
@@ -74,7 +74,8 @@ magma_int_t magma_zscal_zgeru_nopiv_vbatched(
             dim3 grid(magma_ceildiv(ibatch,tbx), 1, 1);
 
             zscal_zgeru_nopiv_tinypivots_kernel_vbatched<<<grid, threads, 0, queue->cuda_stream()>>>
-            (max_M, max_N, M, N, dA_array, Ai, Aj, ldda, dtol_array, eps, info_array, batchCount);
+            (max_M, max_N, M+i, N+i, dA_array+i, Ai, Aj, ldda+i, (dtol_array ? dtol_array+i : NULL), 
+                eps, info_array+i, batchCount);
         }
     }
     // Now call the regular scal and geru routine

--- a/magmablas/zgetf2_nopiv_kernels_var.cu
+++ b/magmablas/zgetf2_nopiv_kernels_var.cu
@@ -75,7 +75,7 @@ magma_int_t magma_zscal_zgeru_nopiv_vbatched(
 
             zscal_zgeru_nopiv_tinypivots_kernel_vbatched<<<grid, threads, 0, queue->cuda_stream()>>>
             (max_M, max_N, M+i, N+i, dA_array+i, Ai, Aj, ldda+i, (dtol_array ? dtol_array+i : NULL), 
-                eps, info_array+i, batchCount);
+                eps, info_array+i, ibatch);
         }
     }
     // Now call the regular scal and geru routine

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -329,8 +329,11 @@ libmagma_src += \
 # vbatched, GPU interface
 libmagma_src += \
 	$(cdir)/zgetf2_vbatched.cpp		\
+	$(cdir)/zgetf2_nopiv_vbatched.cpp		\
 	$(cdir)/zgetrf_panel_vbatched.cpp		\
 	$(cdir)/zgetrf_vbatched.cpp		\
+	$(cdir)/zgetrf_nopiv_panel_vbatched.cpp		\
+	$(cdir)/zgetrf_nopiv_vbatched.cpp		\
 	$(cdir)/zpotf2_vbatched.cpp		\
 	$(cdir)/zpotrf_panel_vbatched.cpp		\
 	$(cdir)/zpotrf_vbatched.cpp		\

--- a/src/zgetf2_nopiv_vbatched.cpp
+++ b/src/zgetf2_nopiv_vbatched.cpp
@@ -18,7 +18,7 @@ magma_zgetf2_nopiv_vbatched_v1(
     magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
     magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
     magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
-    double* dtol_array, magma_int_t *info_array,
+    double* dtol_array, double eps, magma_int_t *info_array,
     magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue)
 {
 #define dA_array(i,j) dA_array, (i), (j)
@@ -33,7 +33,7 @@ magma_zgetf2_nopiv_vbatched_v1(
         for(magma_int_t jj = 0; jj < ib; jj++) {
             magma_int_t gbj = j+jj;
             // scal+ger
-            magma_zscal_zgeru_nopiv_vbatched( max_m-gbj, ib-jj, m, n, dA_array(Ai+gbj, Aj+gbj), ldda, dtol_array, info_array, gbj, gbstep, batchCount, queue);
+            magma_zscal_zgeru_nopiv_vbatched( max_m-gbj, ib-jj, m, n, dA_array(Ai+gbj, Aj+gbj), ldda, dtol_array, eps, info_array, gbj, gbstep, batchCount, queue);
         }
 
         // trsm
@@ -107,11 +107,16 @@ magma_zgetf2_nopiv_vbatched_v1(
     ldda    INTEGER
             The leading dimension of each array A.  LDDA >= max(1,M).
 
-    @param[out]
-    ipiv_array  Array of pointers, dimension (batchCount), for corresponding matrices.
-            Each is an INTEGER array, dimension (min(M,N))
-            The pivot indices; for 1 <= i <= min(M,N), row i of the
-            matrix was interchanged with row IPIV(i).
+    @param[in]
+    dtol_array  Array of DOUBLEs, dimension (batchCount), for corresponding matrices.
+            Each is an the tolerance that is compared to the diagonal element before
+            the column is scaled by its inverse. If the value of the diagonal is less 
+            than the threshold, the diagonal is replaced by the threshold.
+            If the array is set to NULL, then the threshold is set to the eps parameter
+
+    @param[in]
+    eps     DOUBLE
+            The value to use for the tolerance for all matrices if the dtol_array is NULL
 
     @param[out]
     info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
@@ -121,7 +126,8 @@ magma_zgetf2_nopiv_vbatched_v1(
       -     > 0:  if INFO = i, U(i,i) is exactly zero. The factorization
                   has been completed, but the factor U is exactly
                   singular, and division by zero will occur if it is used
-                  to solve a system of equations.
+                  to solve a system of equations. If a tolerance array is specified
+                  the value shows the number of times a tiny pivot was replaced 
 
     @param[in]
     gbstep  INTEGER
@@ -145,7 +151,7 @@ magma_zgetf2_nopiv_vbatched(
     magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
     magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
     magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
-    double *dtol_array, magma_int_t *info_array,
+    double *dtol_array, double eps, magma_int_t *info_array,
     magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue)
 {
     magma_int_t arginfo = -1;
@@ -155,7 +161,7 @@ magma_zgetf2_nopiv_vbatched(
                 max_m, max_n, max_minmn, max_mxn,
                 m, n,
                 dA_array, Ai, Aj, ldda,
-                dtol_array, info_array,
+                dtol_array, eps, info_array,
                 batchCount, queue);
     if(arginfo == 0) return arginfo;
 
@@ -163,7 +169,7 @@ magma_zgetf2_nopiv_vbatched(
         m, n,
         minmn, max_m, max_n, max_minmn, max_mxn,
         dA_array, Ai, Aj, ldda,
-        dtol_array, info_array, gbstep,
+        dtol_array, eps, info_array, gbstep,
         batchCount, queue);
 
     return 0;

--- a/src/zgetf2_nopiv_vbatched.cpp
+++ b/src/zgetf2_nopiv_vbatched.cpp
@@ -1,0 +1,171 @@
+/*
+   -- MAGMA (version 2.0) --
+   Univ. of Tennessee, Knoxville
+   Univ. of California, Berkeley
+   Univ. of Colorado, Denver
+   @date
+
+   @author Azzam Haidar
+   @author Tingxing Dong
+
+   @precisions normal z -> s d c
+*/
+#include "magma_internal.h"
+#include "batched_kernel_param.h"
+
+static magma_int_t
+magma_zgetf2_nopiv_vbatched_v1(
+    magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
+    magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
+    double* dtol_array, magma_int_t *info_array,
+    magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue)
+{
+#define dA_array(i,j) dA_array, (i), (j)
+
+    magma_int_t arginfo = 0;
+
+    magma_int_t j;
+    magma_int_t nb = 8;
+
+    for(j=0; j < max_minmn; j+=nb) {
+        magma_int_t ib = min(nb, max_minmn-j);
+        for(magma_int_t jj = 0; jj < ib; jj++) {
+            magma_int_t gbj = j+jj;
+            // scal+ger
+            magma_zscal_zgeru_nopiv_vbatched( max_m-gbj, ib-jj, m, n, dA_array(Ai+gbj, Aj+gbj), ldda, dtol_array, info_array, gbj, gbstep, batchCount, queue);
+        }
+
+        // trsm
+        magmablas_ztrsm_vbatched_core(
+            MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+            ib, max_n-j-ib, m, n, MAGMA_Z_ONE,
+            dA_array(Ai+j, Aj+j   ), ldda,
+            dA_array(Ai+j, Aj+j+ib), ldda, batchCount, queue );
+
+        // gemm
+        magmablas_zgemm_vbatched_core(
+            MagmaNoTrans, MagmaNoTrans,
+            max_m-j-ib, max_n-j-ib, ib,
+            m, n, minmn,
+            MAGMA_Z_NEG_ONE, dA_array, Ai+j+ib, Aj+j,    ldda,
+                             dA_array, Ai+j,    Aj+j+ib, ldda,
+            MAGMA_Z_ONE,     dA_array, Ai+j+ib, Aj+j+ib, ldda,
+            batchCount, queue );
+    }
+
+    return arginfo;
+
+#undef dA_array
+}
+
+
+
+/***************************************************************************//**
+    Purpose
+    -------
+    ZGETF2 computes an LU factorization of a general M-by-N matrix A
+    using partial pivoting with row interchanges.
+
+    The factorization has the form
+        A = P * L * U
+    where P is a permutation matrix, L is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and U is upper
+    triangular (upper trapezoidal if m < n).
+
+    This is the right-looking Level 3 BLAS version of the algorithm.
+
+    This is a batched version that factors batchCount M-by-N matrices in parallel.
+    dA, ipiv, and info become arrays with one entry per matrix.
+
+    Arguments
+    ---------
+    @param[in]
+    m       INTEGER
+            The number of rows of each matrix A.  M >= 0.
+
+    @param[in]
+    n       INTEGER
+            The number of columns of each matrix A.  N >= 0.
+
+    @param[in,out]
+    dA_array    Array of pointers, dimension (batchCount).
+            Each is a COMPLEX_16 array on the GPU, dimension (LDDA,N).
+            On entry, each pointer is an M-by-N matrix to be factored.
+            On exit, the factors L and U from the factorization
+            A = P*L*U; the unit diagonal elements of L are not stored.
+
+    @param[in]
+    ai      INTEGER
+            Row offset for A.
+
+    @param[in]
+    aj      INTEGER
+            Column offset for A.
+
+    @param[in]
+    ldda    INTEGER
+            The leading dimension of each array A.  LDDA >= max(1,M).
+
+    @param[out]
+    ipiv_array  Array of pointers, dimension (batchCount), for corresponding matrices.
+            Each is an INTEGER array, dimension (min(M,N))
+            The pivot indices; for 1 <= i <= min(M,N), row i of the
+            matrix was interchanged with row IPIV(i).
+
+    @param[out]
+    info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
+      -     = 0:  successful exit
+      -     < 0:  if INFO = -i, the i-th argument had an illegal value
+                  or another error occured, such as memory allocation failed.
+      -     > 0:  if INFO = i, U(i,i) is exactly zero. The factorization
+                  has been completed, but the factor U is exactly
+                  singular, and division by zero will occur if it is used
+                  to solve a system of equations.
+
+    @param[in]
+    gbstep  INTEGER
+            internal use.
+
+    @param[in]
+    batchCount  INTEGER
+                The number of matrices to operate on.
+
+    @param[in]
+    queue   magma_queue_t
+            Queue to execute in.
+
+    this is an internal routine that might have many assumption.
+
+
+    @ingroup magma_getf2_batched
+*******************************************************************************/
+extern "C" magma_int_t
+magma_zgetf2_nopiv_vbatched(
+    magma_int_t *m, magma_int_t *n, magma_int_t* minmn,
+    magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+    magmaDoubleComplex **dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t *ldda,
+    double *dtol_array, magma_int_t *info_array,
+    magma_int_t gbstep, magma_int_t batchCount, magma_queue_t queue)
+{
+    magma_int_t arginfo = -1;
+
+    // first, test the fused panel
+    arginfo = magma_zgetf2_nopiv_fused_vbatched(
+                max_m, max_n, max_minmn, max_mxn,
+                m, n,
+                dA_array, Ai, Aj, ldda,
+                dtol_array, info_array,
+                batchCount, queue);
+    if(arginfo == 0) return arginfo;
+
+    magma_zgetf2_nopiv_vbatched_v1(
+        m, n,
+        minmn, max_m, max_n, max_minmn, max_mxn,
+        dA_array, Ai, Aj, ldda,
+        dtol_array, info_array, gbstep,
+        batchCount, queue);
+
+    return 0;
+}
+

--- a/src/zgetrf_nopiv_panel_vbatched.cpp
+++ b/src/zgetrf_nopiv_panel_vbatched.cpp
@@ -1,0 +1,82 @@
+/*
+   -- MAGMA (version 2.0) --
+   Univ. of Tennessee, Knoxville
+   Univ. of California, Berkeley
+   Univ. of Colorado, Denver
+   @date
+
+   @author Azzam Haidar
+   @author Tingxing Dong
+
+   @precisions normal z -> s d c
+*/
+#include "magma_internal.h"
+
+#define PRECISION_z
+
+// always assume for every matrix m >= n
+// then max_minmn = max_n
+magma_int_t
+magma_zgetrf_nopiv_recpanel_vbatched(
+    magma_int_t* m, magma_int_t* n, magma_int_t* minmn,
+    magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn,
+    magma_int_t max_mxn, magma_int_t min_recpnb,
+    magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
+    double* dtol_array,
+    magma_int_t *info_array, magma_int_t gbstep,
+    magma_int_t batchCount,  magma_queue_t queue)
+{
+#define dA_array(i,j)    dA_array, i, j
+
+    if( max_n <= min_recpnb ) {
+        magma_zgetf2_nopiv_vbatched(
+            m, n, minmn,
+            max_m, max_n, max_minmn, max_mxn,
+            dA_array, Ai, Aj, ldda,
+            dtol_array, info_array,
+            gbstep, batchCount, queue);
+    }
+    else {
+        magma_int_t max_n1 = max( min_recpnb, max_n / 2);
+        magma_int_t max_n2 = max_n - max_n1;
+        magma_int_t new_max_minmn = max_m * max_n1;
+        // panel
+        magma_zgetrf_nopiv_recpanel_vbatched(
+            m, n, minmn,
+            max_m, max_n1, max_n1, new_max_minmn, min_recpnb,
+            dA_array(Ai, Aj), ldda,
+            dtol_array,
+            info_array, gbstep, batchCount, queue);
+
+        // trsm
+        magmablas_ztrsm_vbatched_core(
+            MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+            max_n1, max_n2, m, n, MAGMA_Z_ONE,
+            dA_array(Ai, Aj       ), ldda,
+            dA_array(Ai, Aj+max_n1), ldda,
+            batchCount, queue );
+
+        // gemm
+        magmablas_zgemm_vbatched_core(
+            MagmaNoTrans, MagmaNoTrans,
+            max_m-max_n1, max_n2, max_n1,
+            m, n, minmn,
+            MAGMA_Z_NEG_ONE, dA_array(Ai+max_n1, Aj       ), ldda,
+                             dA_array(Ai       , Aj+max_n1), ldda,
+            MAGMA_Z_ONE,     dA_array(Ai+max_n1, Aj+max_n1), ldda,
+            batchCount, queue );
+
+        // panel 2
+        new_max_minmn = (max_m-max_n1) * max_n2;
+        magma_zgetrf_nopiv_recpanel_vbatched(
+            m, n, minmn,
+            max_m-max_n1, max_n2, max_n2, new_max_minmn, min_recpnb,
+            dA_array(Ai+max_n1, Aj+max_n1), ldda,
+            dtol_array,
+            info_array, gbstep+max_n1, batchCount, queue);
+    }
+
+    return 0;
+
+#undef dA_array
+}

--- a/src/zgetrf_nopiv_panel_vbatched.cpp
+++ b/src/zgetrf_nopiv_panel_vbatched.cpp
@@ -22,7 +22,7 @@ magma_zgetrf_nopiv_recpanel_vbatched(
     magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn,
     magma_int_t max_mxn, magma_int_t min_recpnb,
     magmaDoubleComplex** dA_array, magma_int_t Ai, magma_int_t Aj, magma_int_t* ldda,
-    double* dtol_array,
+    double* dtol_array, double eps,
     magma_int_t *info_array, magma_int_t gbstep,
     magma_int_t batchCount,  magma_queue_t queue)
 {
@@ -33,7 +33,7 @@ magma_zgetrf_nopiv_recpanel_vbatched(
             m, n, minmn,
             max_m, max_n, max_minmn, max_mxn,
             dA_array, Ai, Aj, ldda,
-            dtol_array, info_array,
+            dtol_array, eps, info_array,
             gbstep, batchCount, queue);
     }
     else {
@@ -45,7 +45,7 @@ magma_zgetrf_nopiv_recpanel_vbatched(
             m, n, minmn,
             max_m, max_n1, max_n1, new_max_minmn, min_recpnb,
             dA_array(Ai, Aj), ldda,
-            dtol_array,
+            dtol_array, eps,
             info_array, gbstep, batchCount, queue);
 
         // trsm
@@ -72,7 +72,7 @@ magma_zgetrf_nopiv_recpanel_vbatched(
             m, n, minmn,
             max_m-max_n1, max_n2, max_n2, new_max_minmn, min_recpnb,
             dA_array(Ai+max_n1, Aj+max_n1), ldda,
-            dtol_array,
+            dtol_array, eps,
             info_array, gbstep+max_n1, batchCount, queue);
     }
 

--- a/src/zgetrf_nopiv_vbatched.cpp
+++ b/src/zgetrf_nopiv_vbatched.cpp
@@ -20,7 +20,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
         magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
         magma_int_t nb, magma_int_t recnb,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double* dtol_array,
+        double* dtol_array, double eps,
         magma_int_t *info_array, magma_int_t batchCount,
         magma_queue_t queue)
 {
@@ -37,7 +37,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
                     max_m, max_n, max_minmn, max_mxn,
                     m, n,
                     dA_array, 0, 0, ldda,
-                    dtol_array, 
+                    dtol_array, eps,
                     info_array, batchCount, queue );
 
         if(arginfo == 0) return arginfo;
@@ -52,7 +52,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
                     m, n, minmn,
                     pm, ib, ib, max_mxn, recnb,
                     dA_array(i, i), ldda,
-                    dtol_array,
+                    dtol_array, eps,
                     info_array, i, batchCount, queue);
 
         if (arginfo != 0 ) return arginfo;
@@ -148,7 +148,11 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
             Each is an the tolerance that is compared to the diagonal element before
             the column is scaled by its inverse. If the value of the diagonal is less 
             than the threshold, the diagonal is replaced by the threshold.
-            If the array is set to NULL, then the threshold is set to the machine epsilon
+            If the array is set to NULL, then the threshold is set to the eps parameter
+
+    @param[in]
+    eps     DOUBLE
+            The value to use for the tolerance for all matrices if the dtol_array is NULL
 
     @param[out]
     info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
@@ -158,7 +162,8 @@ magma_zgetrf_nopiv_vbatched_max_nocheck(
       -     > 0:  if INFO = i, U(i,i) is exactly zero. The factorization
                   has been completed, but the factor U is exactly
                   singular, and division by zero will occur if it is used
-                  to solve a system of equations.
+                  to solve a system of equations. If a tolerance array is specified
+                  the value shows the number of times a tiny pivot was replaced 
 
     @param[in]
     WORK        VOID pointer
@@ -185,7 +190,7 @@ magma_zgetrf_nopiv_vbatched_max_nocheck_work(
         magma_int_t* m, magma_int_t* n,
         magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double *dtol_array, magma_int_t *info_array,
+        double *dtol_array, double eps, magma_int_t *info_array,
         void* work, magma_int_t* lwork,
         magma_int_t batchCount, magma_queue_t queue)
 {
@@ -223,8 +228,146 @@ magma_zgetrf_nopiv_vbatched_max_nocheck_work(
                 max_m, max_n, max_minmn, max_mxn,
                 nb, recnb,
                 dA_array, ldda,
-                dtol_array, info_array,
+                dtol_array, eps, info_array,
                 batchCount, queue);
+}
+
+/***************************************************************************//**
+    Purpose
+    -------
+    ZGETRF NOPIV computes an LU factorization of a general M-by-N matrix A
+    without pivoting. It replaces tiny pivots smaller than a specified tolerance
+    by that tolernace
+
+    The factorization has the form
+        A = L * U
+    where L is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and U is upper
+    triangular (upper trapezoidal if m < n).
+
+    This is the right-looking Level 3 BLAS version of the algorithm.
+
+    This is the variable-size batched version, which factors batchCount matrices of
+    different sizes in parallel. Each matrix is assumed to have its own size and leading
+    dimension.
+
+    This is the expert version taking an extra parameter for the tolerance for diagonal 
+    elements. Small diagonal elements will be replaced by the specified tolerance preserving
+    the sign and the info array will report the number of replacements. This is useful in the 
+    context of static pivoting used in sparse solvers such as SuperLU, where the tolerance would
+    be the the norm of the matrix scaled by the machine epsilon for example. 
+
+    Arguments
+    ---------
+    @param[in]
+    M       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of rows of each matrix A.  M[i] >= 0.
+
+    @param[in]
+    N       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of columns of each matrix A.  N[i] >= 0.
+
+    @param[in,out]
+    dA_array    Array of pointers on the GPU, dimension (batchCount).
+            Each is a COMPLEX_16 array on the GPU, dimension (LDDA[i],N[i]).
+            On entry, each pointer is an M[i]-by-N[i] matrix to be factored.
+            On exit, the factors L and U from the factorization
+            A = L*U; the unit diagonal elements of L are not stored.
+
+    @param[in]
+    ldda    Array of INTEGERs on the GPU
+            Each is the leading dimension of each array A.  LDDA[i] >= max(1,M[i]).
+
+    @param[in]
+    dtol_array  Array of DOUBLEs, dimension (batchCount), for corresponding matrices.
+            Each is an the tolerance that is compared to the diagonal element before
+            the column is scaled by its inverse. If the value of the diagonal is less 
+            than the threshold, the diagonal is replaced by the threshold.
+            If the array is set to NULL, then the threshold is set to the eps parameter
+
+    @param[in]
+    eps     DOUBLE
+            The value to use for the tolerance for all matrices if the dtol_array is NULL
+
+    @param[out]
+    info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
+      -     = 0:  successful exit
+      -     < 0:  if INFO = -i, the i-th argument had an illegal value
+                  or another error occured, such as memory allocation failed.
+      -     > 0:  if INFO = i, U(i,i) is exactly zero. The factorization
+                  has been completed, but the factor U is exactly
+                  singular, and division by zero will occur if it is used
+                  to solve a system of equations. If a tolerance array is specified
+                  the value shows the number of times a tiny pivot was replaced 
+
+    @param[in]
+    batchCount  INTEGER
+                The number of matrices to operate on.
+
+    @param[in]
+    queue   magma_queue_t
+            Queue to execute in.
+
+    @ingroup magma_getrf_batched
+*******************************************************************************/
+extern "C" magma_int_t
+magma_zgetrf_nopiv_expert_vbatched(
+        magma_int_t* m, magma_int_t* n,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, double eps, magma_int_t *info_array,
+        magma_int_t batchCount, magma_queue_t queue)
+{
+    // error checker needs 3 integers, while the setup kernel requires 4
+    // so allocate 4
+    const magma_int_t stats_length = 4;
+
+    magma_int_t arginfo = 0, hstats[stats_length];
+    magma_int_t *stats;
+    magma_imalloc(&stats, stats_length);    // max_m, max_n, max_minmn, max_mxn
+
+    // the checker requires that stats contains at least 3 integers
+    arginfo = magma_getrf_vbatched_checker( m, n, ldda, stats, batchCount, queue );
+
+    if (arginfo != 0) {
+        magma_xerbla( __func__, -(arginfo) );
+    }
+    else {
+        void* device_work;
+        magma_int_t lwork[1];
+
+        // collect stats (requires at least 4 integers)
+        magma_getrf_vbatched_setup( m, n, stats, batchCount, queue );
+        magma_igetvector(stats_length, stats, 1, hstats, 1, queue);
+        const magma_int_t max_m     = hstats[0];
+        const magma_int_t max_n     = hstats[1];
+        const magma_int_t max_minmn = hstats[2];
+        const magma_int_t max_mxn   = hstats[3];
+
+        // query workspace
+        lwork[0] = -1;
+        magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+            NULL, NULL,
+            max_m, max_n, max_minmn, max_mxn,
+            NULL, NULL, NULL, eps, NULL,
+            NULL, lwork, batchCount, queue);
+
+        // alloc workspace
+        magma_malloc( (void**)&device_work, lwork[0] );
+
+        arginfo = magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+                    m, n,
+                    max_m, max_n, max_minmn, max_mxn,
+                    dA_array, ldda,
+                    dtol_array, eps, info_array,
+                    device_work, lwork,
+                    batchCount, queue);
+
+        magma_queue_sync( queue );
+        magma_free( device_work );
+    }
+
+    magma_free(stats);
+    return arginfo;
 }
 
 /***************************************************************************//**
@@ -267,13 +410,6 @@ magma_zgetrf_nopiv_vbatched_max_nocheck_work(
     ldda    Array of INTEGERs on the GPU
             Each is the leading dimension of each array A.  LDDA[i] >= max(1,M[i]).
 
-    @param[in]
-    dtol_array  Array of DOUBLEs, dimension (batchCount), for corresponding matrices.
-            Each is an the tolerance that is compared to the diagonal element before
-            the column is scaled by its inverse. If the value of the diagonal is less 
-            than the threshold, the diagonal is replaced by the threshold.
-            If the array is set to NULL, then the threshold is set to the machine epsilon
-
     @param[out]
     info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
       -     = 0:  successful exit
@@ -291,62 +427,13 @@ magma_zgetrf_nopiv_vbatched_max_nocheck_work(
 
     @ingroup magma_getrf_batched
 *******************************************************************************/
-extern "C" magma_int_t
+magma_int_t
 magma_zgetrf_nopiv_vbatched(
         magma_int_t* m, magma_int_t* n,
         magmaDoubleComplex **dA_array, magma_int_t *ldda,
-        double *dtol_array, magma_int_t *info_array,
-        magma_int_t batchCount, magma_queue_t queue)
-{
-    // error checker needs 3 integers, while the setup kernel requires 4
-    // so allocate 4
-    const magma_int_t stats_length = 4;
+        magma_int_t *info_array,
+        magma_int_t batchCount, magma_queue_t queue) {
 
-    magma_int_t arginfo = 0, hstats[stats_length];
-    magma_int_t *stats;
-    magma_imalloc(&stats, stats_length);    // max_m, max_n, max_minmn, max_mxn
-
-    // the checker requires that stats contains at least 3 integers
-    arginfo = magma_getrf_vbatched_checker( m, n, ldda, stats, batchCount, queue );
-
-    if (arginfo != 0) {
-        magma_xerbla( __func__, -(arginfo) );
-    }
-    else {
-        void* device_work;
-        magma_int_t lwork[1];
-
-        // collect stats (requires at least 4 integers)
-        magma_getrf_vbatched_setup( m, n, stats, batchCount, queue );
-        magma_igetvector(stats_length, stats, 1, hstats, 1, queue);
-        const magma_int_t max_m     = hstats[0];
-        const magma_int_t max_n     = hstats[1];
-        const magma_int_t max_minmn = hstats[2];
-        const magma_int_t max_mxn   = hstats[3];
-
-        // query workspace
-        lwork[0] = -1;
-        magma_zgetrf_nopiv_vbatched_max_nocheck_work(
-            NULL, NULL,
-            max_m, max_n, max_minmn, max_mxn,
-            NULL, NULL, NULL, NULL,
-            NULL, lwork, batchCount, queue);
-
-        // alloc workspace
-        magma_malloc( (void**)&device_work, lwork[0] );
-
-        arginfo = magma_zgetrf_nopiv_vbatched_max_nocheck_work(
-                    m, n,
-                    max_m, max_n, max_minmn, max_mxn,
-                    dA_array, ldda,
-                    dtol_array, info_array,
-                    device_work, lwork,
-                    batchCount, queue);
-
-        magma_queue_sync( queue );
-        magma_free( device_work );
-    }
-
-    magma_free(stats);
-    return arginfo;
+        return magma_zgetrf_nopiv_expert_vbatched(
+                m, n, dA_array, ldda, NULL, 0, info_array, batchCount, queue);
 }

--- a/src/zgetrf_nopiv_vbatched.cpp
+++ b/src/zgetrf_nopiv_vbatched.cpp
@@ -1,0 +1,352 @@
+/*
+   -- MAGMA (version 2.0) --
+   Univ. of Tennessee, Knoxville
+   Univ. of California, Berkeley
+   Univ. of Colorado, Denver
+   @date
+
+   @author Azzam Haidar
+   @author Tingxing Dong
+
+   @precisions normal z -> s d c
+*/
+
+#include "magma_internal.h"
+#include "batched_kernel_param.h"
+
+extern "C" magma_int_t
+magma_zgetrf_nopiv_vbatched_max_nocheck(
+        magma_int_t* m, magma_int_t* n, magma_int_t* minmn,
+        magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+        magma_int_t nb, magma_int_t recnb,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double* dtol_array,
+        magma_int_t *info_array, magma_int_t batchCount,
+        magma_queue_t queue)
+{
+#define dA_array(i_, j_)  dA_array, i_, j_
+
+    magma_int_t arginfo = 0;
+    magma_int_t ib, i, pm;
+
+    magma_memset_async(info_array, 0, batchCount*sizeof(magma_int_t), queue);
+
+    // try a fused kernel for small sizes
+    if( max_m <= 32 && max_n <= 32) {
+        arginfo = magma_zgetf2_nopiv_fused_vbatched(
+                    max_m, max_n, max_minmn, max_mxn,
+                    m, n,
+                    dA_array, 0, 0, ldda,
+                    dtol_array, 
+                    info_array, batchCount, queue );
+
+        if(arginfo == 0) return arginfo;
+    }
+
+    for (i = 0; i < max_minmn; i += nb) {
+        ib = min(nb, max_minmn-i);
+        pm = max_m-i;
+
+        // panel
+        arginfo = magma_zgetrf_nopiv_recpanel_vbatched(
+                    m, n, minmn,
+                    pm, ib, ib, max_mxn, recnb,
+                    dA_array(i, i), ldda,
+                    dtol_array,
+                    info_array, i, batchCount, queue);
+
+        if (arginfo != 0 ) return arginfo;
+        
+        if ( (i + ib) < max_n){
+            // trsm
+            magmablas_ztrsm_vbatched_core(
+                    MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+                    ib, max_n-i-ib, m, n, MAGMA_Z_ONE,
+                    dA_array(i, i), ldda,
+                    dA_array(i, i+ib), ldda,
+                    batchCount, queue );
+
+            if ( (i + ib) < max_m){
+                // gemm update
+                magmablas_zgemm_vbatched_core(
+                        MagmaNoTrans, MagmaNoTrans,
+                        max_m-i-ib, max_n-i-ib, ib,
+                        m, n, minmn,
+                        MAGMA_Z_NEG_ONE, dA_array(i+ib, i   ), ldda,
+                                         dA_array(i   , i+ib), ldda,
+                        MAGMA_Z_ONE,     dA_array(i+ib, i+ib), ldda,
+                        batchCount, queue );
+            } // end of  if ( (i + ib) < max_m)
+
+        } // end of if ( (i + ib) < max_n)
+
+    }// end of for
+
+    return arginfo;
+
+#undef dA_array
+}
+
+/***************************************************************************//**
+    Purpose
+    -------
+    ZGETRF NOPIV computes an LU factorization of a general M-by-N matrix A
+    without pivoting. It replaces tiny pivots smaller than a specified tolerance
+    by that tolernace
+
+    The factorization has the form
+        A = L * U
+    where L is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and U is upper
+    triangular (upper trapezoidal if m < n).
+
+    This is the right-looking Level 3 BLAS version of the algorithm.
+
+    This is the variable-size batched version, which factors batchCount matrices of
+    different sizes in parallel. Each matrix is assumed to have its own size and leading
+    dimension.
+
+    Arguments
+    ---------
+    @param[in]
+    M       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of rows of each matrix A.  M[i] >= 0.
+
+    @param[in]
+    N       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of columns of each matrix A.  N[i] >= 0.
+
+    @param[in]
+    MAX_M   INTEGER
+            The maximum number of rows across the batch
+
+    @param[in]
+    MAX_N   INTEGER
+            The maximum number of columns across the batch
+
+    @param[in]
+    MAX_MINMN INTEGER
+              The maximum value of min(Mi, Ni) for i = 1, 2, ..., batchCount
+
+    @param[in]
+    MAX_MxN INTEGER
+            The maximum value of the product (Mi x Ni) for i = 1, 2, ..., batchCount
+
+    @param[in,out]
+    dA_array    Array of pointers on the GPU, dimension (batchCount).
+            Each is a COMPLEX_16 array on the GPU, dimension (LDDA[i],N[i]).
+            On entry, each pointer is an M[i]-by-N[i] matrix to be factored.
+            On exit, the factors L and U from the factorization
+            A = L*U; the unit diagonal elements of L are not stored.
+
+    @param[in]
+    ldda    Array of INTEGERs on the GPU
+            Each is the leading dimension of each array A.  LDDA[i] >= max(1,M[i]).
+
+    @param[in]
+    dtol_array  Array of DOUBLEs, dimension (batchCount), for corresponding matrices.
+            Each is an the tolerance that is compared to the diagonal element before
+            the column is scaled by its inverse. If the value of the diagonal is less 
+            than the threshold, the diagonal is replaced by the threshold.
+            If the array is set to NULL, then the threshold is set to the machine epsilon
+
+    @param[out]
+    info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
+      -     = 0:  successful exit
+      -     < 0:  if INFO = -i, the i-th argument had an illegal value
+                  or another error occured, such as memory allocation failed.
+      -     > 0:  if INFO = i, U(i,i) is exactly zero. The factorization
+                  has been completed, but the factor U is exactly
+                  singular, and division by zero will occur if it is used
+                  to solve a system of equations.
+
+    @param[in]
+    WORK        VOID pointer
+                A workspace of size LWORK[0]
+
+    @param[inout]
+    LWORK       INTEGER pointer
+                If lwork[0] < 0, a workspace query is assumed, and lwork[0] is
+                overwritten by the required workspace size in bytes.
+                Otherwise, lwork[0] is the size of work
+
+    @param[in]
+    batchCount  INTEGER
+                The number of matrices to operate on.
+
+    @param[in]
+    queue   magma_queue_t
+            Queue to execute in.
+
+    @ingroup magma_getrf_batched
+*******************************************************************************/
+extern "C" magma_int_t
+magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+        magma_int_t* m, magma_int_t* n,
+        magma_int_t max_m, magma_int_t max_n, magma_int_t max_minmn, magma_int_t max_mxn,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, magma_int_t *info_array,
+        void* work, magma_int_t* lwork,
+        magma_int_t batchCount, magma_queue_t queue)
+{
+    // first calculate required workspace in bytes
+    magma_int_t workspace_bytes = 0;
+    workspace_bytes += batchCount * sizeof(magma_int_t);         // minmn array
+    workspace_bytes  = magma_roundup(workspace_bytes, 128);      // multiple of 128 bytes
+
+    if( *lwork < 0 ) {
+        // workspace query is assumed
+        *lwork = workspace_bytes;
+        return 0;
+    }
+
+    // check lwork
+    if( *lwork < workspace_bytes ) {
+        printf("error in %s, not enough workspace (lwork = %lld, required = %lld)\n",
+                __func__, (long long)(*lwork), (long long)workspace_bytes );
+        return -12;    // lwork is not enough
+    }
+
+    // split workspace as needed by magma_zgetrf_nopiv_vbatched_max_nocheck
+    magma_int_t* minmn           = (magma_int_t*)work;
+    
+    // init
+    magma_ivec_min_vv( batchCount, m, n, minmn, queue);
+
+    // blocking sizes
+    magma_int_t nb, recnb;
+    magma_get_zgetrf_vbatched_nbparam(max_m, max_n, &nb, &recnb);
+
+    // call magma_zgetrf_nopiv_vbatched_max_nocheck
+    return magma_zgetrf_nopiv_vbatched_max_nocheck(
+                m, n, minmn,
+                max_m, max_n, max_minmn, max_mxn,
+                nb, recnb,
+                dA_array, ldda,
+                dtol_array, info_array,
+                batchCount, queue);
+}
+
+/***************************************************************************//**
+    Purpose
+    -------
+    ZGETRF NOPIV computes an LU factorization of a general M-by-N matrix A
+    without pivoting. It replaces tiny pivots smaller than a specified tolerance
+    by that tolernace
+
+    The factorization has the form
+        A = L * U
+    where L is lower triangular with unit
+    diagonal elements (lower trapezoidal if m > n), and U is upper
+    triangular (upper trapezoidal if m < n).
+
+    This is the right-looking Level 3 BLAS version of the algorithm.
+
+    This is the variable-size batched version, which factors batchCount matrices of
+    different sizes in parallel. Each matrix is assumed to have its own size and leading
+    dimension.
+
+    Arguments
+    ---------
+    @param[in]
+    M       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of rows of each matrix A.  M[i] >= 0.
+
+    @param[in]
+    N       Array of INTEGERs on the GPU, dimension (batchCount)
+            Each is the number of columns of each matrix A.  N[i] >= 0.
+
+    @param[in,out]
+    dA_array    Array of pointers on the GPU, dimension (batchCount).
+            Each is a COMPLEX_16 array on the GPU, dimension (LDDA[i],N[i]).
+            On entry, each pointer is an M[i]-by-N[i] matrix to be factored.
+            On exit, the factors L and U from the factorization
+            A = L*U; the unit diagonal elements of L are not stored.
+
+    @param[in]
+    ldda    Array of INTEGERs on the GPU
+            Each is the leading dimension of each array A.  LDDA[i] >= max(1,M[i]).
+
+    @param[in]
+    dtol_array  Array of DOUBLEs, dimension (batchCount), for corresponding matrices.
+            Each is an the tolerance that is compared to the diagonal element before
+            the column is scaled by its inverse. If the value of the diagonal is less 
+            than the threshold, the diagonal is replaced by the threshold.
+            If the array is set to NULL, then the threshold is set to the machine epsilon
+
+    @param[out]
+    info_array  Array of INTEGERs, dimension (batchCount), for corresponding matrices.
+      -     = 0:  successful exit
+      -     < 0:  if INFO = -i, the i-th argument had an illegal value
+                  or another error occured, such as memory allocation failed.
+      -     > 0:  if INFO = i, there were i tiny pivot replacements 
+
+    @param[in]
+    batchCount  INTEGER
+                The number of matrices to operate on.
+
+    @param[in]
+    queue   magma_queue_t
+            Queue to execute in.
+
+    @ingroup magma_getrf_batched
+*******************************************************************************/
+extern "C" magma_int_t
+magma_zgetrf_nopiv_vbatched(
+        magma_int_t* m, magma_int_t* n,
+        magmaDoubleComplex **dA_array, magma_int_t *ldda,
+        double *dtol_array, magma_int_t *info_array,
+        magma_int_t batchCount, magma_queue_t queue)
+{
+    // error checker needs 3 integers, while the setup kernel requires 4
+    // so allocate 4
+    const magma_int_t stats_length = 4;
+
+    magma_int_t arginfo = 0, hstats[stats_length];
+    magma_int_t *stats;
+    magma_imalloc(&stats, stats_length);    // max_m, max_n, max_minmn, max_mxn
+
+    // the checker requires that stats contains at least 3 integers
+    arginfo = magma_getrf_vbatched_checker( m, n, ldda, stats, batchCount, queue );
+
+    if (arginfo != 0) {
+        magma_xerbla( __func__, -(arginfo) );
+    }
+    else {
+        void* device_work;
+        magma_int_t lwork[1];
+
+        // collect stats (requires at least 4 integers)
+        magma_getrf_vbatched_setup( m, n, stats, batchCount, queue );
+        magma_igetvector(stats_length, stats, 1, hstats, 1, queue);
+        const magma_int_t max_m     = hstats[0];
+        const magma_int_t max_n     = hstats[1];
+        const magma_int_t max_minmn = hstats[2];
+        const magma_int_t max_mxn   = hstats[3];
+
+        // query workspace
+        lwork[0] = -1;
+        magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+            NULL, NULL,
+            max_m, max_n, max_minmn, max_mxn,
+            NULL, NULL, NULL, NULL,
+            NULL, lwork, batchCount, queue);
+
+        // alloc workspace
+        magma_malloc( (void**)&device_work, lwork[0] );
+
+        arginfo = magma_zgetrf_nopiv_vbatched_max_nocheck_work(
+                    m, n,
+                    max_m, max_n, max_minmn, max_mxn,
+                    dA_array, ldda,
+                    dtol_array, info_array,
+                    device_work, lwork,
+                    batchCount, queue);
+
+        magma_queue_sync( queue );
+        magma_free( device_work );
+    }
+
+    magma_free(stats);
+    return arginfo;
+}

--- a/testing/Makefile.src
+++ b/testing/Makefile.src
@@ -233,6 +233,7 @@ testing_src += \
 	\
 	$(cdir)/testing_zpotrf_vbatched.cpp	\
 	$(cdir)/testing_zgetrf_vbatched.cpp	\
+	$(cdir)/testing_zgetrf_nopiv_vbatched.cpp	\
 
 # ----------
 # half precision files

--- a/testing/testing_zgetrf_nopiv_vbatched.cpp
+++ b/testing/testing_zgetrf_nopiv_vbatched.cpp
@@ -221,8 +221,7 @@ int main( int argc, char** argv)
                 magma_time = magma_sync_wtime( opts.queue );
                 info = magma_zgetrf_nopiv_vbatched(
                         d_M, d_N,
-                        dA_array, d_ldda,
-                        NULL, dinfo,
+                        dA_array, d_ldda, dinfo,
                         batchCount, opts.queue);
                 magma_time = magma_sync_wtime( opts.queue ) - magma_time;
             }
@@ -236,7 +235,7 @@ int main( int argc, char** argv)
                         d_M, d_N, d_min_mn,
                         max_M, max_N, max_minMN, max_MxN, nb, 32,
                         dA_array, d_ldda,
-                        NULL, dinfo,
+                        NULL, 0, dinfo,
                         batchCount, opts.queue);
                 magma_time = magma_sync_wtime( opts.queue ) - magma_time;
             }

--- a/testing/testing_zgetrf_nopiv_vbatched.cpp
+++ b/testing/testing_zgetrf_nopiv_vbatched.cpp
@@ -1,0 +1,333 @@
+/*
+   -- MAGMA (version 2.0) --
+   Univ. of Tennessee, Knoxville
+   Univ. of California, Berkeley
+   Univ. of Colorado, Denver
+   @date
+
+   @author Ahmad Abdelfattah
+
+   @precisions normal z -> s d c
+ */
+// includes, system
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+// includes, project
+#include "flops.h"
+#include "magma_v2.h"
+#include "magma_lapack.h"
+#include "testings.h"
+
+#if defined(_OPENMP)
+#include <omp.h>
+#include "../control/magma_threadsetting.h"  // internal header
+#endif
+
+#define PRECISION_z
+
+// uncomment to use mkl's group batch interface
+//#define USE_MKL_GETRF_BATCH
+
+// uncomment to introduce singularity in one matrix
+// by setting two different columns to zeros
+// (edit MTX_ID, COL1, and COL2 accordingly)
+//#define SINGULARITY_CHECK
+#ifdef SINGULARITY_CHECK
+#define MTX_ID (10)    // checked against batchCount
+#define COL1   (1)     // checked against #columns
+#define COL2   (10)    // checked against #columns
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+double get_LU_error(magma_int_t M, magma_int_t N,
+                    magmaDoubleComplex *A,  magma_int_t lda,
+                    magmaDoubleComplex *LU)
+{
+    magma_int_t min_mn = min(M, N);
+    magma_int_t i, j;
+    magmaDoubleComplex alpha = MAGMA_Z_ONE;
+    magmaDoubleComplex beta  = MAGMA_Z_ZERO;
+    magmaDoubleComplex *L, *U;
+    double work[1], matnorm, residual;
+
+    TESTING_CHECK( magma_zmalloc_cpu( &L, M*min_mn ));
+    TESTING_CHECK( magma_zmalloc_cpu( &U, min_mn*N ));
+    memset( L, 0, M*min_mn*sizeof(magmaDoubleComplex) );
+    memset( U, 0, min_mn*N*sizeof(magmaDoubleComplex) );
+
+    lapackf77_zlacpy( MagmaLowerStr, &M, &min_mn, LU, &lda, L, &M      );
+    lapackf77_zlacpy( MagmaUpperStr, &min_mn, &N, LU, &lda, U, &min_mn );
+
+    for (j=0; j < min_mn; j++)
+        L[j+j*M] = MAGMA_Z_MAKE( 1., 0. );
+
+    matnorm = lapackf77_zlange("f", &M, &N, A, &lda, work);
+
+    blasf77_zgemm("N", "N", &M, &N, &min_mn,
+                  &alpha, L, &M, U, &min_mn, &beta, LU, &lda);
+
+    for( j = 0; j < N; j++ ) {
+        for( i = 0; i < M; i++ ) {
+            LU[i+j*lda] = MAGMA_Z_SUB( LU[i+j*lda], A[i+j*lda] );
+        }
+    }
+    residual = lapackf77_zlange("f", &M, &N, LU, &lda, work);
+
+    magma_free_cpu( L );
+    magma_free_cpu( U );
+
+    return residual / (matnorm * N);
+}
+
+/* ////////////////////////////////////////////////////////////////////////////
+   -- Testing zgetrf_batched
+*/
+int main( int argc, char** argv)
+{
+    TESTING_CHECK( magma_init() );
+    magma_print_environment();
+
+    real_Double_t   gflops=0, magma_perf=0, magma_time=0, cpu_perf=0, cpu_time=0;
+    real_Double_t   NbyM;
+    double          error;
+    magma_int_t     hA_size = 0, dA_size = 0;
+    magma_int_t     seed = 0;
+    magmaDoubleComplex *hA, *hR, *hA_magma, *hTmp;
+    magmaDoubleComplex *dA;
+    magmaDoubleComplex **dA_array = NULL, **hA_array = NULL, **hR_array = NULL, **hdA_array = NULL;
+
+    magma_int_t     *hinfo;
+    magma_int_t     *dinfo;
+
+    magma_int_t *h_M = NULL, *h_N = NULL, *h_lda  = NULL, *h_ldda = NULL, *h_min_mn = NULL;
+    magma_int_t *d_M = NULL, *d_N = NULL, *d_ldda = NULL, *d_min_mn;
+    magma_int_t iM, iN, max_M=0, max_N=0, max_minMN=0, max_MxN=0, info;
+    magma_int_t ione     = 1;
+    magma_int_t ISEED[4] = {0,0,0,1};
+    magma_int_t batchCount;
+    int status = 0;
+
+    magma_opts opts( MagmaOptsBatched );
+    opts.parse_opts( argc, argv );
+    opts.lapack |= (opts.check == 2);
+    double tol = opts.tolerance * lapackf77_dlamch("E");
+
+    batchCount = opts.batchcount;
+
+    TESTING_CHECK( magma_imalloc_cpu(&h_M,      batchCount) );
+    TESTING_CHECK( magma_imalloc_cpu(&h_N,      batchCount) );
+    TESTING_CHECK( magma_imalloc_cpu(&h_lda,    batchCount) );
+    TESTING_CHECK( magma_imalloc_cpu(&h_ldda,   batchCount) );
+    TESTING_CHECK( magma_imalloc_cpu(&h_min_mn, batchCount) );
+    TESTING_CHECK( magma_imalloc_cpu(&hinfo,    batchCount ));
+
+    TESTING_CHECK( magma_imalloc(&d_M,      batchCount) );
+    TESTING_CHECK( magma_imalloc(&d_N,      batchCount) );
+    TESTING_CHECK( magma_imalloc(&d_ldda,   batchCount) );
+    TESTING_CHECK( magma_imalloc(&d_min_mn, batchCount) );
+    TESTING_CHECK( magma_imalloc(&dinfo,    batchCount ));
+
+    TESTING_CHECK( magma_malloc_cpu((void**)&hA_array,  batchCount * sizeof(magmaDoubleComplex*)) );
+    TESTING_CHECK( magma_malloc_cpu((void**)&hR_array,  batchCount * sizeof(magmaDoubleComplex*)) );
+    TESTING_CHECK( magma_malloc_cpu((void**)&hdA_array, batchCount * sizeof(magmaDoubleComplex*)) );
+    TESTING_CHECK( magma_malloc(    (void**)&dA_array,  batchCount * sizeof(magmaDoubleComplex*)) );
+
+    printf("%%             max   max\n");
+    printf("%% BatchCount   M     N    CPU Gflop/s (ms)   MAGMA Gflop/s (ms)   ||PA-LU||/(||A||*N)\n");
+    printf("%%==========================================================================================================\n");
+    for( int itest = 0; itest < opts.ntest; ++itest ) {
+        seed = rand();
+        for( int iter = 0; iter < opts.niter; ++iter ) {
+            srand(seed);    // necessary to have the same sizes across different iterations
+
+            iM = opts.msize[itest];
+            iN = opts.nsize[itest];
+            NbyM  = (real_Double_t)iN / (real_Double_t)iM;
+
+            hA_size  = 0;
+            dA_size  = 0;
+            gflops   = 0;
+
+            for(int s = 0; s < batchCount; s++) {
+                h_M[s]      = 1 + (rand() % iM);
+                h_N[s]      = max(1, (magma_int_t) round(NbyM * real_Double_t(h_M[s])) ); // try to keep the M/N ratio
+                max_M       = (s == 0) ? h_M[s] : max(h_M[s], max_M);
+                max_N       = (s == 0) ? h_N[s] : max(h_N[s], max_N);
+                h_lda[s]    = h_M[s];
+                h_ldda[s]   = h_lda[s]; //magma_roundup( h_M[s], opts.align );  // multiple of 32 by default
+                h_min_mn[s] = min( h_M[s], h_N[s] );
+                max_minMN   = (s == 0) ? h_min_mn[s] : max(h_min_mn[s], max_minMN);
+                max_MxN     = (s == 0) ? h_M[s] * h_N[s] : max(h_M[s] * h_N[s], max_MxN);
+                hA_size    += h_lda[s]  * h_N[s];
+                dA_size    += h_ldda[s] * h_N[s];
+                gflops     += FLOPS_ZGETRF( h_M[s], h_N[s] ) / 1e9;
+            }
+
+            TESTING_CHECK( magma_zmalloc_cpu( &hA,       hA_size  ));
+            TESTING_CHECK( magma_zmalloc_cpu( &hA_magma, hA_size  ));
+            TESTING_CHECK( magma_zmalloc_pinned( &hR,    hA_size  ));
+
+            TESTING_CHECK( magma_zmalloc( &dA,       dA_size ));
+
+            /* Initialize ptr arrays */
+            hA_array [0]    = hA;
+            hR_array [0]    = hR;
+            hdA_array[0]    = dA;
+            for(int s = 1; s < batchCount; s++) {
+                hA_array[s]     = hA_array[s-1]  + h_lda[s-1]  * h_N[s-1];
+                hR_array[s]     = hR_array[s-1]  + h_lda[s-1]  * h_N[s-1];
+                hdA_array[s]    = hdA_array[s-1] + h_ldda[s-1] * h_N[s-1];
+            }
+
+            /* Initialize hA and copy to hR */
+            lapackf77_zlarnv( &ione, ISEED, &hA_size, hA );
+
+            #ifdef SINGULARITY_CHECK
+            // introduce singularity -- for debugging purpose only
+            magma_int_t id   = min(MTX_ID, batchCount-1);
+            magma_int_t col1 = min(COL1, h_N[id]-1);
+            magma_int_t col2 = min(COL2, h_N[id]-1);
+            printf("singularity in matrix %lld of size (%lld, %lld) : col. %lld & %lld set to zeros\n",
+                   (long long)id, (long long)h_M[id], (long long)h_N[id],
+                   (long long)col1, (long long)col2);
+            memset(hA_array[id] + col1 * h_lda[id], 0, h_M[id] * sizeof(magmaDoubleComplex));
+            memset(hA_array[id] + col2 * h_lda[id], 0, h_M[id] * sizeof(magmaDoubleComplex));
+            #endif
+
+            memcpy(hR, hA, hA_size * sizeof(magmaDoubleComplex));
+
+            /* ====================================================================
+               Performs operation using MAGMA
+               =================================================================== */
+            magma_setvector(batchCount, sizeof(magmaDoubleComplex*), hdA_array, 1, dA_array, 1, opts.queue);
+            magma_isetvector(batchCount, h_M,    1, d_M,    1, opts.queue);
+            magma_isetvector(batchCount, h_N,    1, d_N,    1, opts.queue);
+            magma_isetvector(batchCount, h_ldda, 1, d_ldda, 1, opts.queue);
+            magma_isetvector(batchCount, h_min_mn, 1, d_min_mn, 1, opts.queue);
+
+            for(int s = 0; s < batchCount; s++) {
+                magma_zsetmatrix( h_M[s], h_N[s],
+                                  hR_array[s],  h_lda[s],
+                                  hdA_array[s], h_ldda[s], opts.queue );
+            }
+
+            if(opts.version == 1) {
+                // main API, with error checking and
+                // workspace allocation
+                magma_time = magma_sync_wtime( opts.queue );
+                info = magma_zgetrf_nopiv_vbatched(
+                        d_M, d_N,
+                        dA_array, d_ldda,
+                        NULL, dinfo,
+                        batchCount, opts.queue);
+                magma_time = magma_sync_wtime( opts.queue ) - magma_time;
+            }
+            else {
+                // advanced API, totally asynchronous,
+                // but requires some setup
+                magma_time = magma_sync_wtime( opts.queue );
+                magma_int_t nb, recnb;
+                magma_get_zgetrf_vbatched_nbparam(max_M, max_N, &nb, &recnb);
+                info = magma_zgetrf_nopiv_vbatched_max_nocheck(
+                        d_M, d_N, d_min_mn,
+                        max_M, max_N, max_minMN, max_MxN, nb, 32,
+                        dA_array, d_ldda,
+                        NULL, dinfo,
+                        batchCount, opts.queue);
+                magma_time = magma_sync_wtime( opts.queue ) - magma_time;
+            }
+            magma_perf = gflops / magma_time;
+
+            hTmp = hA_magma;
+            for(int s = 0; s < batchCount; s++) {
+                magma_zgetmatrix( h_M[s], h_N[s], hdA_array[s], h_ldda[s], hTmp, h_lda[s], opts.queue );
+                hTmp += h_lda[s] * h_N[s];
+            }
+
+            // check info
+            magma_getvector( batchCount, sizeof(magma_int_t), dinfo, 1, hinfo, 1, opts.queue );
+            // for (int i=0; i < batchCount; i++) {
+            //     if (hinfo[i] != 0 ) {
+            //         printf("magma_zgetrf_batched matrix %lld returned internal error %lld\n",
+            //                 (long long) i, (long long) hinfo[i] );
+            //     }
+            // }
+
+            // if (info != 0) {
+            //     printf("magma_zgetrf_batched returned argument error %lld: %s.\n",
+            //             (long long) info, magma_strerror( info ));
+            // }
+
+            /* =====================================================================
+               Check the factorization
+               =================================================================== */
+            if ( opts.lapack ) {
+                printf("%10lld %5lld %5lld   %7.2f (%7.2f)    %7.2f (%7.2f) ",
+                       (long long) batchCount, (long long) max_M, (long long) max_N,
+                       cpu_perf, cpu_time*1000.,
+                       magma_perf, magma_time*1000.  );
+            }
+            else {
+                printf("%10lld %5lld %5lld     ---   (  ---  )    %7.2f (%7.2f) ",
+                       (long long) batchCount, (long long) max_M, (long long) max_N,
+                       magma_perf, magma_time*1000. );
+            }
+
+            if ( opts.check == 1 ) {
+                hA_array[0] = hA_magma;
+                for(int s = 1; s < batchCount; s++) {
+                    hA_array[s] = hA_array[s-1] + h_lda[s-1] * h_N[s-1];
+                }
+
+                error = 0;
+                #pragma omp parallel for reduction(max:error)
+                for (int s=0; s < batchCount; s++) {
+                    double err = get_LU_error( h_M[s], h_N[s], hR_array[s], h_lda[s], hA_array[s]);
+                    error = magma_max_nan( err, error );
+                }
+
+                bool okay = (error < tol);
+                status += ! okay;
+                printf("   %8.2e   %s\n", error, (okay ? "ok" : "failed") );
+            }
+            else {
+                printf("     ---\n");
+            }
+
+            magma_free_cpu( hA );
+            magma_free_cpu( hA_magma );
+            magma_free_pinned( hR );
+
+            magma_free( dA );
+            fflush( stdout );
+        }
+        if ( opts.niter > 1 ) {
+            printf( "\n" );
+        }
+    }
+
+    magma_free( d_M );
+    magma_free( d_N );
+    magma_free( d_ldda );
+    magma_free( d_min_mn );
+    magma_free( dA_array );
+    magma_free( dinfo );
+
+    magma_free_cpu( h_M );
+    magma_free_cpu( h_N );
+    magma_free_cpu( h_lda );
+    magma_free_cpu( h_ldda );
+    magma_free_cpu( h_min_mn );
+    magma_free_cpu( hA_array );
+    magma_free_cpu( hR_array );
+    magma_free_cpu( hdA_array );
+    magma_free_cpu( hinfo );
+
+    opts.cleanup();
+    TESTING_CHECK( magma_finalize() );
+    return status;
+}


### PR DESCRIPTION
Hi,

I've added support for variable batch size nonpivoted getrf, used by SuperLU in its batched sparse LU factorization. 
Please let me know if anything needs to be added/changed. 