### PR TITLE
Minor fixes to build with both CUDA < 11 and >= 11

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -46,6 +46,8 @@ single (s), double (d), single-complex (c), double-complex (z).
       updated. Users are advised to check the documentation for the new workspace sizes.
       - magma_<T>gegqr_gpu
       - magma_<T>geqp3_gpu (still backward compatible)
+    * The magma_*gbtf2_native and magma_*gbtf2_native_v2 routines have been disabled
+      for CUDA <11.0.
     * Bug fixes and improvements:
       - magma_zgeqp3_gpu: Fix failures at certain sizes (only double-complex)
       - magma_<T>gesv_rbt_batched: Fix incorrect results for certain sizes
@@ -55,6 +57,9 @@ single (s), double (d), single-complex (c), double-complex (z).
       - Fixes and improvements to CMake
       - Add support for Ada Lovelace architecture in Makefile
       - Fixes to documentation
+      - Fix shpotrf_gpu to work for CUDA <11.0
+      - Sparse: fix a bug in the use of cuSPARSE CSR -> CSC conversion for CUDA >=11.0
+      - Sparse: fix initialization in LSQR solver for non-zero initial guesses
 
 2.8.0 - Mar 25, 2024
     * New functionality: band LU factorization and solve

--- a/magmablas/zgbtf2_kernels.cu
+++ b/magmablas/zgbtf2_kernels.cu
@@ -191,6 +191,7 @@ magma_zgbtf2_scal_ger_batched(
 }
 
 /******************************************************************************/
+#if CUDA_VERSION >= 11000
 __global__
 void zgbtf2_native_kernel(
     int m, int n, int nb, int kl, int ku,
@@ -415,6 +416,7 @@ magma_zgbtf2_native_work(
 
     return *info;
 }
+#endif
 
 /******************************************************************************/
 extern "C"
@@ -424,6 +426,10 @@ magma_zgbtf2_native(
     magmaDoubleComplex* dA, magma_int_t ldda, magma_int_t* ipiv,
     magma_int_t* info, magma_queue_t queue)
 {
+#if CUDA_VERSION < 11000
+    fprintf( stderr, "%s is not supported for CUDA < 11.0\n", __func__);
+    *info = MAGMA_ERR_NOT_SUPPORTED;
+#else
     magma_int_t kv    = kl + ku;
     magma_int_t mband = kv + 1 + kl;
 
@@ -454,12 +460,14 @@ magma_zgbtf2_native(
     magma_zgbtf2_native_work(m, n, kl, ku, dA, ldda, ipiv, info, device_work, lwork, queue);
 
     magma_free(device_work);
+#endif
     return *info;
 }
 
 /******************************************************************************/
 // kernel for gbtf2 using cooperative groups and 1D cyclic dist. of columns
 // among thread-blocks
+#if CUDA_VERSION >= 11000
 __global__
 void zgbtf2_native_kernel_v2(
     int m, int n, int nb, int NB, int kl, int ku,
@@ -713,6 +721,7 @@ magma_zgbtf2_native_v2_work(
 
     return *info;
 }
+#endif
 
 /******************************************************************************/
 extern "C"
@@ -722,6 +731,10 @@ magma_zgbtf2_native_v2(
     magmaDoubleComplex* dA, magma_int_t ldda, magma_int_t* ipiv,
     magma_int_t* info, magma_queue_t queue)
 {
+#if CUDA_VERSION < 11000
+    fprintf( stderr, "%s is not supported for CUDA < 11.0\n", __func__);
+    *info = MAGMA_ERR_NOT_SUPPORTED;
+#else
     magma_int_t kv    = kl + ku;
     magma_int_t mband = kv + 1 + kl;
 
@@ -752,6 +765,6 @@ magma_zgbtf2_native_v2(
     magma_zgbtf2_native_v2_work(m, n, kl, ku, dA, ldda, ipiv, info, device_work, lwork, queue);
 
     magma_free(device_work);
+#endif
     return *info;
 }
-

--- a/sparse/control/magma_zmconvert.cpp
+++ b/sparse/control/magma_zmconvert.cpp
@@ -27,11 +27,11 @@
         size_t bufsize;                                                                        \
         void *buf;                                                                             \
         cusparseCsr2cscEx2_bufferSize(handle, m, n, nnz, valA, rowA, colA,                     \
-                                      valB, rowB, colB, CUDA_C_64F, action, base,              \
+                                      valB, colB, rowB, CUDA_C_64F, action, base,              \
                                       CUSPARSE_CSR2CSC_ALG1, &bufsize);                        \
         if (bufsize > 0)                                                                       \
            CHECK( magma_malloc(&buf, bufsize) );                                                        \
-        cusparseCsr2cscEx2(handle, m, n, nnz, valA, rowA, colA, valB, rowB, colB,              \
+        cusparseCsr2cscEx2(handle, m, n, nnz, valA, rowA, colA, valB, colB, rowB,              \
                            CUDA_C_64F, action, base, CUSPARSE_CSR2CSC_ALG1, buf);              \
         if (bufsize > 0)                                                                       \
            magma_free(buf);                                                                    \
@@ -1820,7 +1820,7 @@ magma_zmconvert(
             // conversion using CUSPARSE
             cusparseZcsr2csc(cusparseHandle, A.num_rows, A.num_cols, A.nnz,
                              (cuDoubleComplex*)A.dval, A.drow, A.dcol,
-                             (cuDoubleComplex*)B->dval, B->dcol, B->drow,
+                             (cuDoubleComplex*)B->dval, B->drow, B->dcol,
                              CUSPARSE_ACTION_NUMERIC,
                              CUSPARSE_INDEX_BASE_ZERO);
         }
@@ -1849,7 +1849,7 @@ magma_zmconvert(
             // conversion using CUSPARSE
             cusparseZcsr2csc(cusparseHandle, A.num_cols, A.num_rows, A.nnz,
                              (cuDoubleComplex*)A.dval, A.dcol, A.drow,
-                             (cuDoubleComplex*)B->dval, B->drow, B->dcol,
+                             (cuDoubleComplex*)B->dval, B->dcol, B->drow,
                              CUSPARSE_ACTION_NUMERIC,
                              CUSPARSE_INDEX_BASE_ZERO);
         }

--- a/sparse/control/magma_zmtranspose.cpp
+++ b/sparse/control/magma_zmtranspose.cpp
@@ -27,11 +27,11 @@
         size_t bufsize;                                                                        \
         void *buf;                                                                             \
         cusparseCsr2cscEx2_bufferSize(handle, m, n, nnz, valA, rowA, colA,                     \
-                                      valB, colB, rowB, CUDA_C_64F, action, base,              \
+                                      valB, rowB, colB, CUDA_C_64F, action, base,              \
                                       CUSPARSE_CSR2CSC_ALG1, &bufsize);                        \
         if (bufsize > 0)                                                                       \
            CHECK( magma_malloc(&buf, bufsize) );                                               \
-        cusparseCsr2cscEx2(handle, m, n, nnz, valA, rowA, colA, valB, colB, rowB,              \
+        cusparseCsr2cscEx2(handle, m, n, nnz, valA, rowA, colA, valB, rowB, colB,              \
                            CUDA_C_64F, action, base, CUSPARSE_CSR2CSC_ALG1, buf);              \
         if (bufsize > 0)                                                                       \
            magma_free(buf);                                                                    \
@@ -324,7 +324,7 @@ magma_z_cucsrtranspose(
         CHECK_CUSPARSE( cusparseSetMatIndexBase( descrA, CUSPARSE_INDEX_BASE_ZERO ));
         CHECK_CUSPARSE( cusparseSetMatIndexBase( descrB, CUSPARSE_INDEX_BASE_ZERO ));
         cusparseZcsr2csc( handle, A.num_rows, A.num_cols, A.nnz,
-                          (cuDoubleComplex*)A.dval, A.drow, A.dcol, (cuDoubleComplex*)B->dval, B->drow, B->dcol,
+                          (cuDoubleComplex*)A.dval, A.drow, A.dcol, (cuDoubleComplex*)B->dval, B->dcol, B->drow,
                           CUSPARSE_ACTION_NUMERIC,
                           CUSPARSE_INDEX_BASE_ZERO);
     } else if ( A.storage_type == Magma_CSR && A.memory_location == Magma_CPU ){
@@ -432,7 +432,7 @@ magma_zmtransposeconjugate(
         CHECK_CUSPARSE( cusparseSetMatIndexBase( descrA, CUSPARSE_INDEX_BASE_ZERO ));
         CHECK_CUSPARSE( cusparseSetMatIndexBase( descrB, CUSPARSE_INDEX_BASE_ZERO ));
         cusparseZcsr2csc( handle, A.num_rows, A.num_cols, A.nnz,
-                          (cuDoubleComplex*)A.dval, A.drow, A.dcol, (cuDoubleComplex*)B->dval, B->drow, B->dcol,
+                          (cuDoubleComplex*)A.dval, A.drow, A.dcol, (cuDoubleComplex*)B->dval, B->dcol, B->drow,
                           CUSPARSE_ACTION_NUMERIC,
                           CUSPARSE_INDEX_BASE_ZERO);
         CHECK( magma_zmconjugate( B, queue ));

--- a/sparse/include/magmasparse_types.h
+++ b/sparse/include/magmasparse_types.h
@@ -550,20 +550,20 @@ extern "C"
     #define csrsm2Info_t int
 #endif
 
-#if CUDA_VERSION < 11031 || defined(MAGMA_HAVE_HIP)
 typedef struct magma_solve_info_t
 {
+    #if CUDA_VERSION < 11031 || defined(MAGMA_HAVE_HIP)
     csrsm2Info_t descr{};
-    void *buffer{};
-} magma_solve_info_t;
-//#define magma_ilu_info_t cusparseSolveAnalysisInfo_t
-#define magma_ilu_info_t csrsm2Info_t
-#else
-typedef struct magma_solve_info_t
-{
+    #else
     cusparseSpSMDescr_t descr{};
+    #endif
     void *buffer{};
 } magma_solve_info_t;
+// Older CUDA: use cusparseSolveAnalysisInfo_t
+#if (defined(MAGMA_HAVE_CUDA) && CUDA_VERSION < 11000) 
+#define magma_ilu_info_t cusparseSolveAnalysisInfo_t
+// HIP and newer CUDA: use csrsm2Info_t
+#else
 #define magma_ilu_info_t csrsm2Info_t
 #endif
 

--- a/src/shpotrf_gpu.cpp
+++ b/src/shpotrf_gpu.cpp
@@ -33,7 +33,7 @@ magma_sgemm_fp16(
     magma_queue_t queue )
 {
     #if (defined(MAGMA_HAVE_CUDA) && CUDA_VERSION >= 7500)
-        #ifdef CUDA_USE_FAST_SGEMM
+        #if (defined(CUDA_USE_FAST_SGEMM) && CUDA_VERSION >= 11000)
         cublasGemmEx( queue->cublas_handle(),
                       cublas_trans_const( transA ), cublas_trans_const( transB ),
                       (int)m, (int)n, (int)k,

--- a/testing/testing_sgemm_fp16.cpp
+++ b/testing/testing_sgemm_fp16.cpp
@@ -30,13 +30,23 @@ magma_sgemm_fp16_v1(
     magma_queue_t queue )
 {
     #ifdef MAGMA_HAVE_CUDA
-    cublasGemmEx( magma_queue_get_cublas_handle( queue ),
-                  cublas_trans_const( transA ), cublas_trans_const( transB ),
-                  (int)m, (int)n, (int)k,
-                  (const void*) &alpha, (const void*) dA, CUDA_R_32F, (int)ldda,
-                                        (const void*) dB, CUDA_R_32F, (int)lddb,
-                  (const void*) &beta,  (      void*) dC, CUDA_R_32F, (int)lddc,
-                  CUBLAS_COMPUTE_32F_FAST_16F, CUBLAS_GEMM_DEFAULT_TENSOR_OP );
+      #if CUDA_VERSION >= 11000
+        cublasGemmEx( magma_queue_get_cublas_handle( queue ),
+                      cublas_trans_const( transA ), cublas_trans_const( transB ),
+                      (int)m, (int)n, (int)k,
+                      (const void*) &alpha, (const void*) dA, CUDA_R_32F, (int)ldda,
+                                            (const void*) dB, CUDA_R_32F, (int)lddb,
+                      (const void*) &beta,  (      void*) dC, CUDA_R_32F, (int)lddc,
+                      CUBLAS_COMPUTE_32F_FAST_16F, CUBLAS_GEMM_DEFAULT_TENSOR_OP );
+      #else
+        cublasGemmEx( magma_queue_get_cublas_handle( queue ),
+                      cublas_trans_const( transA ), cublas_trans_const( transB ),
+                      (int)m, (int)n, (int)k,
+                      (const void*) &alpha, (const void*) dA, CUDA_R_32F, (int)ldda,
+                                            (const void*) dB, CUDA_R_32F, (int)lddb,
+                      (const void*) &beta,  (      void*) dC, CUDA_R_32F, (int)lddc,
+                      CUDA_R_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP );
+      #endif
     #else
     magma_int_t hinfo = 0;
     magma_int_t Am = (transA == MagmaNoTrans) ? m : k;


### PR DESCRIPTION
In #32, I accidentally broke CUDA < 11 while fixing the csr2csc function use for CUDA >= 11. By altering the order of the parameters in the macro and not the main source code, we can fix CUDA 11 without breaking CUDA 10 or older.

TODO: 
- [x] Test with CUDA 10
- [x] Test with CUDA 11 (11.0 and 11.4)

Update: When building with CUDA 10.2 to test the sparse changes, I ran into minor issues with some dense routines: shpotrf_gpu (cuBLAS usage) and *gbtf2_native[_v2] (complications building/linking due to cooperative groups). Some minor changes have been added, and the PR title has been updated accordingly. We maintain CUDA 10 support for now, but the *gbtf2_native routines are disabled for CUDA < 11.