### PR TITLE
Include <stdbool.h> header for C

### DIFF
--- a/include/magma_types.h
+++ b/include/magma_types.h
@@ -16,6 +16,9 @@
 #include <stdint.h>
 #include <assert.h>
 
+#ifndef __cplusplus
+#include<stdbool.h>
+#endif
 
 // for backwards compatability
 #ifdef HAVE_clAmdBlas


### PR DESCRIPTION
Includes the `stdbool.h` header for C users. This is necessary due to the addition of two functions with `bool` return type in `magma_z.h` in 1541e88. These routines are intended to be part of the public interface, so they need to stay in the header, despite only being used in one place internally.

Closes #38.