### PR TITLE
Drop CMP0037 to fix cmake 4.0 build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,7 +654,6 @@ endif()
 
 
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SPARSE_TEST_DIR}" )
-cmake_policy( SET CMP0037 OLD)
 foreach( TEST ${sparse_testing_all} )
     string( REGEX REPLACE "\\.(cpp|f90|F90)"     "" EXE ${TEST} )
     string( REGEX REPLACE "${SPARSE_TEST_DIR}/" "" EXE ${EXE} )


### PR DESCRIPTION
Don't know why it is here. Removing it builds fine on my end.

Fixes:
```text
CMake Error at CMakeLists.txt:657 (cmake_policy):
  Policy CMP0037 may not be set to OLD behavior because this version of CMake
  no longer supports it.  The policy was introduced in CMake version 3.0.0,
  and use of NEW behavior is now required.

  Please either update your CMakeLists.txt files to conform to the new
  behavior or use an older version of CMake that still supports the old
  behavior.  Run cmake --help-policy CMP0037 for more information.
```