### PR TITLE
A leaner gesv_rbt_async with improved execution speed and accuracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,23 @@
-cmake_minimum_required( VERSION 3.18 )
+cmake_minimum_required(VERSION 3.18)
 
 # ----------------------------------------
 # to disable Fortran, set this to "off"
 # see also -DADD_ below
-option( USE_FORTRAN "Fortran is required for some tester checks, but can be disabled with reduced functionality" ON )
+option(USE_FORTRAN "Fortran is required for some tester checks, but can be disabled with reduced functionality" ON)
 
 if (USE_FORTRAN)
-    project( MAGMA C CXX Fortran )
-else()
-    project( MAGMA C CXX )
-endif()
+    project(MAGMA C CXX Fortran)
+else ()
+    project(MAGMA C CXX)
+endif ()
 
+FIND_PROGRAM(PROGRAM_CCACHE ccache)
+IF (PROGRAM_CCACHE)
+    SET(CMAKE_CXX_COMPILER_LAUNCHER ${PROGRAM_CCACHE})
+    SET(CMAKE_C_COMPILER_LAUNCHER ${PROGRAM_CCACHE})
+    SET(CMAKE_CUDA_COMPILER_LAUNCHER ${PROGRAM_CCACHE})
+    SET(CMAKE_OPENCL_COMPILER_LAUNCHER ${PROGRAM_CCACHE})
+ENDIF ()
 
 # ----------------------------------------
 # to show compile commands, set this here or use 'make VERBOSE=1'
@@ -18,17 +25,17 @@ endif()
 
 # ----------------------------------------
 # MAGMA requires one backend to be enabled
-option(MAGMA_ENABLE_CUDA     "Enable the CUDA backend"  OFF)
-option(MAGMA_ENABLE_HIP      "Enable the HIP  backend"  OFF)
+option(MAGMA_ENABLE_CUDA "Enable the CUDA backend" OFF)
+option(MAGMA_ENABLE_HIP "Enable the HIP  backend" OFF)
 
 # check if one backend has been enabled
 if (NOT MAGMA_ENABLE_CUDA AND
-    NOT MAGMA_ENABLE_HIP
-    )
-  message(STATUS "MAGMA requires one enabled backend!")
-  message(STATUS "Building CUDA backend")
-  set( MAGMA_ENABLE_CUDA ON )
-endif()
+        NOT MAGMA_ENABLE_HIP
+)
+    message(STATUS "MAGMA requires one enabled backend!")
+    message(STATUS "Building CUDA backend")
+    set(MAGMA_ENABLE_CUDA ON)
+endif ()
 
 # ----------------------------------------
 # don't regenerate files during make.
@@ -40,25 +47,25 @@ set(CMAKE_SUPPRESS_REGENERATION on)
 # ----------------------------------------
 # force an out-of-source build, to not overwrite the existing Makefiles
 # (out-of-source is cleaner, too)
-string( COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" MAGMA_COMPILE_INPLACE )
+string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" MAGMA_COMPILE_INPLACE)
 if (MAGMA_COMPILE_INPLACE)
-    message( FATAL_ERROR "Compiling MAGMA with CMake requires an out-of-source build. To proceed:
+    message(FATAL_ERROR "Compiling MAGMA with CMake requires an out-of-source build. To proceed:
     rm -rf CMakeCache.txt CMakeFiles/   # delete files in ${CMAKE_SOURCE_DIR}
     mkdir build
     cd build
     cmake ..
-    make" )
-endif()
+    make")
+endif ()
 
 
 # ----------------------------------------
 # prefer shared libraries
-option( BUILD_SHARED_LIBS "If on, build shared libraries, otherwise build static libraries" ON )
+option(BUILD_SHARED_LIBS "If on, build shared libraries, otherwise build static libraries" ON)
 
 # prefer /usr/local/magma, instead of /usr/local.
 if (UNIX AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr/local/magma" CACHE PATH "..." FORCE)
-endif()
+endif ()
 
 # ----------------------------------------
 # use C++14 and C99
@@ -70,92 +77,96 @@ CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
 CHECK_CXX_COMPILER_FLAG("-fPIC" COMPILER_SUPPORTS_FPIC)
 if (COMPILER_SUPPORTS_CXX14)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-elseif(COMPILER_SUPPORTS_CXX0X)
+elseif (COMPILER_SUPPORTS_CXX0X)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
+else ()
     message( WARNING "The compiler ${CMAKE_CXX_COMPILER} doesn't support the -std=c++14 flag. Some code may not compile.")
-endif()
+endif ()
 
 CHECK_C_COMPILER_FLAG("-std=c99" COMPILER_SUPPORTS_C99)
 if (COMPILER_SUPPORTS_C99)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-else()
-    message( WARNING "The compiler ${CMAKE_C_COMPILER} doesn't support the -std=c99 flag. Some code may not compile.")
-endif()
+else ()
+    message(WARNING "The compiler ${CMAKE_C_COMPILER} doesn't support the -std=c99 flag. Some code may not compile.")
+endif ()
 
 
 # ----------------------------------------
 # check Fortran name mangling
 if (USE_FORTRAN)
-    include( FortranCInterface )
-    FortranCInterface_HEADER( ${CMAKE_SOURCE_DIR}/include/magma_mangling_cmake.h MACRO_NAMESPACE MAGMA_ )
-else()
+    include(FortranCInterface)
+    FortranCInterface_HEADER(${CMAKE_SOURCE_DIR}/include/magma_mangling_cmake.h MACRO_NAMESPACE MAGMA_)
+else ()
     # set one of -DADD_, -DUPCASE, or -DNOCHANGE. See README.
-    message( STATUS "Building without Fortran compiler" )
-    set( FORTRAN_CONVENTION "-DADD_" CACHE STRING "Fortran calling convention, one of -DADD_, -DNOCHANGE, -DUPCASE" )
-    set_property( CACHE FORTRAN_CONVENTION PROPERTY STRINGS -DADD_ -DNOCHANGE -DUPCASE )
-    message( STATUS "    Using ${FORTRAN_CONVENTION} for Fortran calling convention" )
-    set( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   ${FORTRAN_CONVENTION}" )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FORTRAN_CONVENTION}" )
+    message(STATUS "Building without Fortran compiler")
+    set(FORTRAN_CONVENTION "-DADD_" CACHE STRING "Fortran calling convention, one of -DADD_, -DNOCHANGE, -DUPCASE")
+    set_property(CACHE FORTRAN_CONVENTION PROPERTY STRINGS -DADD_ -DNOCHANGE -DUPCASE)
+    message(STATUS "    Using ${FORTRAN_CONVENTION} for Fortran calling convention")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}   ${FORTRAN_CONVENTION}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FORTRAN_CONVENTION}")
     # see also NVCC_FLAGS below
-endif()
+endif ()
 
 
 # ----------------------------------------
 # locate OpenMP
-find_package( OpenMP )
+find_package(OpenMP)
 if (OPENMP_FOUND)
-    message( STATUS "Found OpenMP" )
-    message( STATUS "    OpenMP_C_FLAGS   ${OpenMP_C_FLAGS}" )
-    message( STATUS "    OpenMP_CXX_FLAGS ${OpenMP_CXX_FLAGS}" )
-    set( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}" )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}" )
-endif()
+    message(STATUS "Found OpenMP")
+    message(STATUS "    OpenMP_C_FLAGS   ${OpenMP_C_FLAGS}")
+    message(STATUS "    OpenMP_CXX_FLAGS ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif ()
 
 # ----------------------------------------
 # locate CUDA libraries
 if (MAGMA_ENABLE_CUDA)
-    enable_language( CUDA )
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+        set(CMAKE_CUDA_COMPILER_WORKS ON) # Fix for intel compiler and CUDA
+    endif ()
+    enable_language(CUDA)
 
-    set( CUDA_NAMES
-         "one or more of "
+    set(CUDA_NAMES
+            "one or more of "
          "Fermi, Kepler, Maxwell, Pascal, Volta, Turing, Ampere, Ada, Hopper, "
-         "or valid sm_XY or sm_XYZ" )
-    set( GPU_TARGET "" CACHE STRING
-         "CUDA architectures to compile for, overrides CMAKE_CUDA_ARCHITECTURES; ${CUDA_NAMES}" )
-    find_package( CUDAToolkit )
+            "or valid sm_XY or sm_XYZ")
+    set(GPU_TARGET "" CACHE STRING
+            "CUDA architectures to compile for, overrides CMAKE_CUDA_ARCHITECTURES; ${CUDA_NAMES}")
+    find_package(CUDAToolkit)
     if (CUDAToolkit_FOUND)
-        message( STATUS "Found CUDA ${CUDA_VERSION}" )
-        message( STATUS "    CUDA_CUDART_LIBRARY: CUDA::cudart" )
+        message(STATUS "Found CUDA ${CUDA_VERSION}")
+        message(STATUS "    CUDA_CUDART_LIBRARY: CUDA::cudart")
         #message( STATUS "    CUDA_CUBLAS_LIBRARIES: CUDA::cublas" )
 
-        include_directories( ${CUDAToolkit_INCLUDE_DIRS} )
+        include_directories(${CUDAToolkit_INCLUDE_DIRS})
+        link_directories(${CUDAToolkit_LIBRARY_DIR})
 
         if (GPU_TARGET)
             # Map names to architectures.
             if (GPU_TARGET MATCHES Fermi)
-                set( GPU_TARGET "${GPU_TARGET} sm_20" )
-            endif()
+                set(GPU_TARGET "${GPU_TARGET} sm_20")
+            endif ()
 
             if (GPU_TARGET MATCHES Kepler)
-                set( GPU_TARGET "${GPU_TARGET} sm_30 sm_35 sm_37" )
-            endif()
+                set(GPU_TARGET "${GPU_TARGET} sm_30 sm_35 sm_37")
+            endif ()
 
             if (GPU_TARGET MATCHES Maxwell)
                 set( GPU_TARGET "${GPU_TARGET} sm_50 sm_52 sm_53" )
-            endif()
+            endif ()
 
             if (GPU_TARGET MATCHES Pascal)
                 set( GPU_TARGET "${GPU_TARGET} sm_60 sm_61 sm_62" )
-            endif()
+            endif ()
 
             if (GPU_TARGET MATCHES Volta)
                 set( GPU_TARGET "${GPU_TARGET} sm_70 sm_72" )
-            endif()
+            endif ()
 
             if (GPU_TARGET MATCHES Turing)
-                set( GPU_TARGET "${GPU_TARGET} sm_75" )
-            endif()
+                set(GPU_TARGET "${GPU_TARGET} sm_75")
+            endif ()
 
             if (GPU_TARGET MATCHES Ampere)
                 set( GPU_TARGET "${GPU_TARGET} sm_80 sm_86 sm_87" )
@@ -163,223 +174,223 @@ if (MAGMA_ENABLE_CUDA)
 
             if (GPU_TARGET MATCHES Ada)
                 set( GPU_TARGET "${GPU_TARGET} sm_89" )
-            endif()
+            endif ()
 
             if (GPU_TARGET MATCHES Hopper)
                 set( GPU_TARGET "${GPU_TARGET} sm_90 sm_90a" )
-            endif()
+            endif ()
 
             # Find all sm_XY and sm_XYZ, then strip off sm_.
             string( REGEX MATCHALL "sm_[0-9][0-9a-z]+" sms "${GPU_TARGET}" )
-            string( REPLACE "sm_" "" __cuda_architectures "${sms}" )
+            string(REPLACE "sm_" "" __cuda_architectures "${sms}")
 
             if (NOT __cuda_architectures)
-                message( FATAL_ERROR
-                         "GPU_TARGET must contain ${CUDA_NAMES}. "
-                         "Was: ${GPU_TARGET}" )
-            endif()
+                message(FATAL_ERROR
+                        "GPU_TARGET must contain ${CUDA_NAMES}. "
+                        "Was: ${GPU_TARGET}")
+            endif ()
 
-            set( CMAKE_CUDA_ARCHITECTURES "${__cuda_architectures}" )
-        endif()
+            set(CMAKE_CUDA_ARCHITECTURES "${__cuda_architectures}")
+        endif ()
 
-        message( STATUS "    Compile for CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}" )
-        set( MAGMA_CUDA_ARCH "${CMAKE_CUDA_ARCHITECTURES}" )
+        message(STATUS "    Compile for CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
+        set(MAGMA_CUDA_ARCH "${CMAKE_CUDA_ARCHITECTURES}")
 
         # Find minimum arch in CMAKE_CUDA_ARCHITECTURES, if they're all numeric.
-        set( min_arch 9999 )
-        foreach( arch ${CMAKE_CUDA_ARCHITECTURES} )
+        set(min_arch 9999)
+        foreach (arch ${CMAKE_CUDA_ARCHITECTURES})
             if (arch MATCHES "^([0-9]+)")  # 80-real, 80-virtual, etc. okay
                 if (CMAKE_MATCH_1 LESS min_arch)
-                    set( min_arch "${CMAKE_MATCH_1}" )
-                endif()
-            else()
-                set( min_arch 0 )  # arch like "native", min unknown
+                    set(min_arch "${CMAKE_MATCH_1}")
+                endif ()
+            else ()
+                set(min_arch 0)  # arch like "native", min unknown
                 break()
-            endif()
-        endforeach()
+            endif ()
+        endforeach ()
         # Append zero, so it is comparable to '__CUDA_ARCH__'
-        set( MAGMA_CUDA_ARCH_MIN "${min_arch}0" )
+        set(MAGMA_CUDA_ARCH_MIN "${min_arch}0")
 
-        add_library( magma_nvcc_flags INTERFACE )
+        add_library(magma_nvcc_flags INTERFACE)
         if (COMPILER_SUPPORTS_FPIC)
             target_compile_options(magma_nvcc_flags
-                INTERFACE
-                $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options;-fPIC,${FORTRAN_CONVENTION}>
+                    INTERFACE
+                    $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options;-fPIC,${FORTRAN_CONVENTION}>
             )
-        else()
+        else ()
             # No Position Independent Code on Windows.
             # Compiler will complain if you add that flag.
             target_compile_options(magma_nvcc_flags
-                INTERFACE
-                $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options;${FORTRAN_CONVENTION}>
+                    INTERFACE
+                    $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options;${FORTRAN_CONVENTION}>
             )
-        endif()
+        endif ()
 
-        set( MAGMA_HAVE_CUDA "1" )
+        set(MAGMA_HAVE_CUDA "1")
 
-        message( STATUS "Define -DMAGMA_HAVE_CUDA -DMAGMA_CUDA_ARCH_MIN=${MAGMA_CUDA_ARCH_MIN}" )
-    else()
-        message( STATUS "Could not find CUDA" )
-    endif()
-endif()
+        message(STATUS "Define -DMAGMA_HAVE_CUDA -DMAGMA_CUDA_ARCH_MIN=${MAGMA_CUDA_ARCH_MIN}")
+    else ()
+        message(STATUS "Could not find CUDA")
+    endif ()
+endif ()
 
 # ----------------------------------------
 # locate HIP/ROCm libraries
 if (MAGMA_ENABLE_HIP)
-  set( GPU_TARGET "gfx900" CACHE STRING "HIP architectures to compile for" )
-  list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/lib/cmake/hip)
-  find_package( HIP )
-  if (HIP_FOUND)
-    message( STATUS "Found HIP ${HIP_VERSION}" )
-    message( STATUS "    HIP_INCLUDE_DIRS:   ${HIP_INCLUDE_DIRS}"   )
-    message( STATUS "GPU_TARGET:  ${GPU_TARGET}"   )
+    set(GPU_TARGET "gfx900" CACHE STRING "HIP architectures to compile for")
+    list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/lib/cmake/hip)
+    find_package(HIP)
+    if (HIP_FOUND)
+        message(STATUS "Found HIP ${HIP_VERSION}")
+        message(STATUS "    HIP_INCLUDE_DIRS:   ${HIP_INCLUDE_DIRS}")
+        message(STATUS "GPU_TARGET:  ${GPU_TARGET}")
 
-    include_directories( ${HIP_INCLUDE_DIRS} )
+        include_directories(${HIP_INCLUDE_DIRS})
 
-    set(HIP_SEPARABLE_COMPILATION ON)
+        set(HIP_SEPARABLE_COMPILATION ON)
 
-    if (GPU_TARGET MATCHES kaveri)
-      set( GPU_TARGET ${GPU_TARGET} gfx700 )
-    endif()
+        if (GPU_TARGET MATCHES kaveri)
+            set(GPU_TARGET ${GPU_TARGET} gfx700)
+        endif ()
 
-    if (GPU_TARGET MATCHES hawaii)
-      set( GPU_TARGET ${GPU_TARGET} gfx701 )
-    endif()
+        if (GPU_TARGET MATCHES hawaii)
+            set(GPU_TARGET ${GPU_TARGET} gfx701)
+        endif ()
 
-    if (GPU_TARGET MATCHES kabini)
-      set( GPU_TARGET ${GPU_TARGET} gfx703 )
-    endif()
+        if (GPU_TARGET MATCHES kabini)
+            set(GPU_TARGET ${GPU_TARGET} gfx703)
+        endif ()
 
-    if (GPU_TARGET MATCHES mullins)
-      set( GPU_TARGET ${GPU_TARGET} gfx703 )
-    endif()
+        if (GPU_TARGET MATCHES mullins)
+            set(GPU_TARGET ${GPU_TARGET} gfx703)
+        endif ()
 
-    if (GPU_TARGET MATCHES bonaire)
-      set( GPU_TARGET ${GPU_TARGET} gfx704 )
-    endif()
+        if (GPU_TARGET MATCHES bonaire)
+            set(GPU_TARGET ${GPU_TARGET} gfx704)
+        endif ()
 
-    if (GPU_TARGET MATCHES carrizo)
-      set( GPU_TARGET ${GPU_TARGET} gfx801 )
-    endif()
+        if (GPU_TARGET MATCHES carrizo)
+            set(GPU_TARGET ${GPU_TARGET} gfx801)
+        endif ()
 
-    if (GPU_TARGET MATCHES iceland)
-      set( GPU_TARGET ${GPU_TARGET} gfx802 )
-    endif()
+        if (GPU_TARGET MATCHES iceland)
+            set(GPU_TARGET ${GPU_TARGET} gfx802)
+        endif ()
 
-    if (GPU_TARGET MATCHES tonga)
-      set( GPU_TARGET ${GPU_TARGET} gfx802 )
-    endif()
+        if (GPU_TARGET MATCHES tonga)
+            set(GPU_TARGET ${GPU_TARGET} gfx802)
+        endif ()
 
-    if (GPU_TARGET MATCHES fiji)
-      set( GPU_TARGET ${GPU_TARGET} gfx803 )
-    endif()
+        if (GPU_TARGET MATCHES fiji)
+            set(GPU_TARGET ${GPU_TARGET} gfx803)
+        endif ()
 
-    if (GPU_TARGET MATCHES polaris10)
-      set( GPU_TARGET ${GPU_TARGET} gfx803 )
-    endif()
+        if (GPU_TARGET MATCHES polaris10)
+            set(GPU_TARGET ${GPU_TARGET} gfx803)
+        endif ()
 
-    if (GPU_TARGET MATCHES tongapro)
-      set( GPU_TARGET ${GPU_TARGET} gfx805 )
-    endif()
+        if (GPU_TARGET MATCHES tongapro)
+            set(GPU_TARGET ${GPU_TARGET} gfx805)
+        endif ()
 
-    if (GPU_TARGET MATCHES stoney)
-      set( GPU_TARGET ${GPU_TARGET} gfx810 )
-    endif()
+        if (GPU_TARGET MATCHES stoney)
+            set(GPU_TARGET ${GPU_TARGET} gfx810)
+        endif ()
 
-    set( DEVCCFLAGS  "" )
-    set(VALID_GFXS "700;701;702;703;704;705;801;802;803;805;810;900;902;904;906;908;909;90c;1010;1011;1012;1030;1031;1032;1033")
-    foreach( GFX ${VALID_GFXS} )
-      if ( GPU_TARGET MATCHES gfx${GFX} )
-        set( DEVCCFLAGS ${DEVCCFLAGS} --offload-arch=gfx${GFX} )
-      endif()
-    endforeach()
+        set(DEVCCFLAGS "")
+        set(VALID_GFXS "700;701;702;703;704;705;801;802;803;805;810;900;902;904;906;908;909;90c;1010;1011;1012;1030;1031;1032;1033")
+        foreach (GFX ${VALID_GFXS})
+            if (GPU_TARGET MATCHES gfx${GFX})
+                set(DEVCCFLAGS ${DEVCCFLAGS} --offload-arch=gfx${GFX})
+            endif ()
+        endforeach ()
 
-    set( DEVCCFLAGS ${DEVCCFLAGS} -fPIC ${FORTRAN_CONVENTION} )
-    set(MAGMA_HAVE_HIP "1")
-    message( STATUS "Define -DMAGMA_HAVE_HIP" )
+        set(DEVCCFLAGS ${DEVCCFLAGS} -fPIC ${FORTRAN_CONVENTION})
+        set(MAGMA_HAVE_HIP "1")
+        message(STATUS "Define -DMAGMA_HAVE_HIP")
 
-    set_property(TARGET hip::device APPEND PROPERTY COMPATIBLE_INTERFACE_BOOL INTERFACE_HIP_DEVICE_COMPILE)
-    set_property(TARGET hip::device PROPERTY INTERFACE_HIP_DEVICE_COMPILE ON)
-    set(GPU_ARCH_FLAGS ${DEVCCFLAGS})
+        set_property(TARGET hip::device APPEND PROPERTY COMPATIBLE_INTERFACE_BOOL INTERFACE_HIP_DEVICE_COMPILE)
+        set_property(TARGET hip::device PROPERTY INTERFACE_HIP_DEVICE_COMPILE ON)
+        set(GPU_ARCH_FLAGS ${DEVCCFLAGS})
 
-    #add_compile_options(${GPU_ARCH_FLAGS})
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__" )
-    option(ROCM_CORE "Location of the rocm-core package")
-    execute_process(COMMAND "${CMAKE_SOURCE_DIR}/tools/get-rocm-version.sh" "${ROCM_CORE}" OUTPUT_VARIABLE ROCM_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-    message(STATUS "ROCM_VERSION=${ROCM_VERSION}")
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCM_VERSION=${ROCM_VERSION}" )
-  else()
-    message( STATUS "Could not find HIP" )
-  endif()
-endif()
+        #add_compile_options(${GPU_ARCH_FLAGS})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__")
+        option(ROCM_CORE "Location of the rocm-core package")
+        execute_process(COMMAND "${CMAKE_SOURCE_DIR}/tools/get-rocm-version.sh" "${ROCM_CORE}" OUTPUT_VARIABLE ROCM_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+        message(STATUS "ROCM_VERSION=${ROCM_VERSION}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCM_VERSION=${ROCM_VERSION}")
+    else ()
+        message(STATUS "Could not find HIP")
+    endif ()
+endif ()
 
 # ----------------------------------------
 # locate LAPACK libraries
 
 set(BLA_VENDOR "" CACHE STRING
-    "Use specified BLAS library. See https://cmake.org/cmake/help/latest/module/FindBLAS.html")
+        "Use specified BLAS library. See https://cmake.org/cmake/help/latest/module/FindBLAS.html")
 
 # List from CMake 3.17, minus some obsolete ones:
 # PhiPACK, Compaq CXML, DEC Alpha DXML, SunPerf, SGI SCSL, SGIMATH,
 # Intel, NAS (Apple veclib).
 # FLAME is BLIS.
 set_property(CACHE BLA_VENDOR PROPERTY STRINGS
-    "" "All" "Goto" "OpenBLAS" "FLAME" "ATLAS" "IBMESSL"
-    "Intel10_64lp" "Intel10_64lp_seq" "Intel10_64ilp" "Intel10_64ilp_seq"
-    "ACML" "ACML_MP" "ACML_GPU"
-    "Apple"
-    "Arm" "Arm_mp" "Arm_ilp64" "Arm_ilp64_mp"
-    "Generic")
+        "" "All" "Goto" "OpenBLAS" "FLAME" "ATLAS" "IBMESSL"
+        "Intel10_64lp" "Intel10_64lp_seq" "Intel10_64ilp" "Intel10_64ilp_seq"
+        "ACML" "ACML_MP" "ACML_GPU"
+        "Apple"
+        "Arm" "Arm_mp" "Arm_ilp64" "Arm_ilp64_mp"
+        "Generic")
 
-set( LAPACK_LIBRARIES "" CACHE STRING "Libraries for LAPACK and BLAS, to manually override search" )
+set(LAPACK_LIBRARIES "" CACHE STRING "Libraries for LAPACK and BLAS, to manually override search")
 if (LAPACK_LIBRARIES STREQUAL "")
-    message( STATUS "Searching for BLAS and LAPACK. To override, set LAPACK_LIBRARIES using ccmake." )
-    find_package( LAPACK )
+    message(STATUS "Searching for BLAS and LAPACK. To override, set LAPACK_LIBRARIES using ccmake.")
+    find_package(LAPACK)
     # force showing updated LAPACK_LIBRARIES in ccmake / cmake-gui.
-    set( LAPACK_LIBRARIES ${LAPACK_LIBRARIES} CACHE STRING "Libraries for LAPACK and BLAS, to manually override search" FORCE )
-else()
-    message( STATUS "User set LAPACK_LIBRARIES. To change, edit LAPACK_LIBRARIES using ccmake (set to empty to enable search)." )
+    set(LAPACK_LIBRARIES ${LAPACK_LIBRARIES} CACHE STRING "Libraries for LAPACK and BLAS, to manually override search" FORCE)
+else ()
+    message(STATUS "User set LAPACK_LIBRARIES. To change, edit LAPACK_LIBRARIES using ccmake (set to empty to enable search).")
     # Check either -lname syntax or file existence
-    foreach( LIB ${LAPACK_LIBRARIES} )
+    foreach (LIB ${LAPACK_LIBRARIES})
         if (NOT LIB MATCHES "^-l[a-zA-Z0-9_-]+$")
-        if (NOT EXISTS ${LIB})
-            message( WARNING "\n      Warning: file ${LIB} does not exist.\n" )
-        endif()
-        endif()
-    endforeach()
-endif()
+            if (NOT EXISTS ${LIB})
+                message(WARNING "\n      Warning: file ${LIB} does not exist.\n")
+            endif ()
+        endif ()
+    endforeach ()
+endif ()
 
 # If using MKL, add it to includes and define MAGMA_WITH_MKL
 # Initially, this gets MKLROOT from environment, but then the user can edit it.
 if (LAPACK_LIBRARIES MATCHES mkl_core)
-    set( MKLROOT $ENV{MKLROOT} CACHE STRING "MKL installation directory" )
+    set(MKLROOT $ENV{MKLROOT} CACHE STRING "MKL installation directory")
     if (MKLROOT STREQUAL "")
-        message( WARNING "LAPACK_LIBRARIES has MKL, but MKLROOT not set; can't add include directory." )
-    else()
-        message( STATUS "MKLROOT set to ${MKLROOT}. To change, edit MKLROOT using ccmake." )
+        message(WARNING "LAPACK_LIBRARIES has MKL, but MKLROOT not set; can't add include directory.")
+    else ()
+        message(STATUS "MKLROOT set to ${MKLROOT}. To change, edit MKLROOT using ccmake.")
         if (NOT EXISTS ${MKLROOT})
-            message( FATAL_ERROR "MKLROOT ${MKLROOT} directory does not exist." )
-        endif()
-        include_directories( ${MKLROOT}/include )
-        add_definitions( -DMAGMA_WITH_MKL )
-        message( STATUS "Define -DMAGMA_WITH_MKL" )
-    endif()
-endif()
+            message(FATAL_ERROR "MKLROOT ${MKLROOT} directory does not exist.")
+        endif ()
+        include_directories(${MKLROOT}/include)
+        add_definitions(-DMAGMA_WITH_MKL)
+        message(STATUS "Define -DMAGMA_WITH_MKL")
+    endif ()
+endif ()
 
 
 # ----------------------------------------
 # save magma.lib, magma_sparse.lib, etc. in lib/
-set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib )
-set( CMAKE_LIBRARY_OUTPUT_DIRECTORY lib )
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY lib)
 
 
 # ----------------------------------------
 # list of sources
 if (MAGMA_ENABLE_CUDA)
-  include( ${CMAKE_SOURCE_DIR}/CMake.src.cuda )
-else()
-  include( ${CMAKE_SOURCE_DIR}/CMake.src.hip )
-endif()
+    include(${CMAKE_SOURCE_DIR}/CMake.src.cuda)
+else ()
+    include(${CMAKE_SOURCE_DIR}/CMake.src.hip)
+endif ()
 
 # ----------------------------------------
 # common flags
@@ -390,20 +401,20 @@ if (WIN32)
     #     -Wall is way too verbose; use -W4
     #     -MP enables parallel builds
     #     -std=c99 is not implemented, so skip that
-    string( REGEX REPLACE " */W3" "" CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}"   )
-    string( REGEX REPLACE " */W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
-    set( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -W4 -MP -DMAGMA_NOAFFINITY" )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W4 -MP -DMAGMA_NOAFFINITY" )
-else()
+    string(REGEX REPLACE " */W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REGEX REPLACE " */W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W4 -MP -DMAGMA_NOAFFINITY")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W4 -MP -DMAGMA_NOAFFINITY")
+else ()
     # Primarily for gcc / nvcc:
     # Ignore unused static functions in headers.
-    set( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -Wall -Wno-unused-function" )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function" )
-endif()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-function")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
+endif ()
 
 if (CMAKE_HOST_APPLE)
     # Use rpaths, which is on by default in CMake 3.
-    set( CMAKE_MACOSX_RPATH 1 )
+    set(CMAKE_MACOSX_RPATH 1)
 
     # 64-bit veclib (Accelerate) has issues; substitute correct functions from LAPACK.
     # (The issue is single precision functions that return doubles;
@@ -411,48 +422,48 @@ if (CMAKE_HOST_APPLE)
     # but this is not feasible in Fortran.)
     if (LAPACK_LIBRARIES MATCHES "Accelerate")
         if (USE_FORTRAN)
-            message( STATUS "MacOS X: adding blas_fix library" )
-            add_library( blas_fix ${libblas_fix_src} )
-            target_link_libraries( blas_fix
-                ${LAPACK_LIBRARIES}
+            message(STATUS "MacOS X: adding blas_fix library")
+            add_library(blas_fix ${libblas_fix_src})
+            target_link_libraries(blas_fix
+                    ${LAPACK_LIBRARIES}
             )
-            set( blas_fix blas_fix )
-            set( blas_fix_lib -lblas_fix )
-        else()
-            message( WARNING "\n      Warning: cannot compile blas_fix library for MacOS X without Fortran compiler.\n" )
-        endif()
-    endif()
+            set(blas_fix blas_fix)
+            set(blas_fix_lib -lblas_fix)
+        else ()
+            message(WARNING "\n      Warning: cannot compile blas_fix library for MacOS X without Fortran compiler.\n")
+        endif ()
+    endif ()
 
-    set( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -DMAGMA_NOAFFINITY" )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAGMA_NOAFFINITY" )
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMAGMA_NOAFFINITY")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAGMA_NOAFFINITY")
 
     # previously, just compile as 32-bit, but CUDA 6.5 no longer has 32-bit FAT libraries
     ## set( CMAKE_C_FLAGS       "${CMAKE_C_FLAGS} -m32" )
     ## set( CMAKE_CXX_FLAGS     "${CMAKE_CXX_FLAGS} -m32" )
     ## set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -m32" )
     ## set( CUDA_64_BIT_DEVICE_CODE OFF )
-endif()
+endif ()
 
-include_directories( "${CMAKE_BINARY_DIR}/include" )
+include_directories("${CMAKE_BINARY_DIR}/include")
 
-include_directories( include )
-include_directories( control )
+include_directories(include)
+include_directories(control)
 if (MAGMA_ENABLE_CUDA)
-  include_directories( magmablas )  # e.g., shuffle.cuh
-else()
-  include_directories( magmablas_hip )  # e.g., shuffle.cuh
-endif()
+    include_directories(magmablas)  # e.g., shuffle.cuh
+else ()
+    include_directories(magmablas_hip)  # e.g., shuffle.cuh
+endif ()
 
 # Need to check sizeof(void*) after setting flags above;
 # CMAKE_SIZEOF_VOID_P can be wrong.
-include( CheckTypeSize )
-CHECK_TYPE_SIZE( void* SIZEOF_VOID_PTR )
+include(CheckTypeSize)
+CHECK_TYPE_SIZE(void* SIZEOF_VOID_PTR)
 if (USE_FORTRAN)
-    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Dmagma_devptr_t=\"integer\(kind=${SIZEOF_VOID_PTR}\)\"" )
-endif()
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Dmagma_devptr_t=\"integer\(kind=${SIZEOF_VOID_PTR}\)\"")
+endif ()
 
 # Configure config
-configure_file(${CMAKE_SOURCE_DIR}/include/magma_config.h.in  ${CMAKE_BINARY_DIR}/include/magma_config.h)
+configure_file(${CMAKE_SOURCE_DIR}/include/magma_config.h.in ${CMAKE_BINARY_DIR}/include/magma_config.h)
 
 # ----------------------------------------
 # compile MAGMA library
@@ -462,24 +473,24 @@ if (WIN32)
     # understand that .F90 files should be pre-processed.
 
     # separate Fortran and C/C++/CUDA files
-    foreach( filename ${libmagma_all} )
+    foreach (filename ${libmagma_all})
         if (filename MATCHES "\\.(f)$")  # |f90|F90
-            list( APPEND libmagma_all_f   ${filename} )
+            list(APPEND libmagma_all_f ${filename})
         elseif (filename MATCHES "\\.(c|cu|cpp)$")
-            list( APPEND libmagma_all_cpp ${filename} )
-        endif()
-    endforeach()
+            list(APPEND libmagma_all_cpp ${filename})
+        endif ()
+    endforeach ()
     #message( "libmagma_all_cpp ${libmagma_all_cpp}" )
     #message( "libmagma_all_f   ${libmagma_all_f}"   )
 
     # on Windows, Fortran files aren't compiled if listed here...
-    add_library( magma ${libmagma_all_cpp} )
-    target_link_libraries( magma
-        ${LAPACK_LIBRARIES}
-        CUDA::cudart
-        CUDA::cublas
-        CUDA::cusparse
-        magma_nvcc_flags
+    add_library(magma ${libmagma_all_cpp})
+    target_link_libraries(magma
+            ${LAPACK_LIBRARIES}
+            CUDA::cudart
+            CUDA::cublas
+            CUDA::cusparse
+            magma_nvcc_flags
     )
 
     # no Fortran files at the moment (how to test libmagma_all_f is not empty?),
@@ -494,51 +505,51 @@ if (WIN32)
     ##     CUDA::cusparse
     ## )
     ## make list of Fortran .mod files to install, as below
-else()
+else ()
     # Unix doesn't seem to have a problem with mixing C, CUDA, and Fortran files
     if (MAGMA_ENABLE_CUDA)
-    #message(FATAL_ERROR "${libmagma_all}")
-      add_library( magma ${libmagma_all} )
-      target_link_libraries( magma
-        ${blas_fix}
-        ${LAPACK_LIBRARIES}
-        CUDA::cudart
-        CUDA::cublas
-        CUDA::cusparse
-        magma_nvcc_flags
+        #message(FATAL_ERROR "${libmagma_all}")
+        add_library(magma ${libmagma_all})
+        target_link_libraries(magma
+                ${blas_fix}
+                ${LAPACK_LIBRARIES}
+                CUDA::cudart
+                CUDA::cublas
+                CUDA::cusparse
+                magma_nvcc_flags
         )
-    else()
-      find_package( hipBLAS )
-      if (hipBLAS_FOUND)
-        message( STATUS "Found rocBLAS ${rocBLAS_VERSION}" )
-      endif()
-      find_package( hipSPARSE )
-      if (hipSPARSE_FOUND)
-        message( STATUS "Found rocSPARSE ${rocSPARSE_VERSION}" )
-      endif()
-      add_library( magma ${libmagma_all} )
-      target_link_libraries( magma
-        hip::host
-        ${blas_fix}
-        ${LAPACK_LIBRARIES}
+    else ()
+        find_package(hipBLAS)
+        if (hipBLAS_FOUND)
+            message(STATUS "Found rocBLAS ${rocBLAS_VERSION}")
+        endif ()
+        find_package(hipSPARSE)
+        if (hipSPARSE_FOUND)
+            message(STATUS "Found rocSPARSE ${rocSPARSE_VERSION}")
+        endif ()
+        add_library(magma ${libmagma_all})
+        target_link_libraries(magma
+                hip::host
+                ${blas_fix}
+                ${LAPACK_LIBRARIES}
         hip::device
-        roc::hipblas
-        roc::hipsparse
+                roc::hipblas
+                roc::hipsparse
         )
-    endif()
+    endif ()
 
     if (USE_FORTRAN)
         # make list of Fortran .mod files to install
-        foreach( filename ${libmagma_all} )
+        foreach (filename ${libmagma_all})
             if (filename MATCHES "\\.(f90|F90)$")
                 # mod files seem to wind up in root build directory
-                get_filename_component( fmod ${filename} NAME_WE )
-                list( APPEND modules "${CMAKE_BINARY_DIR}/${fmod}.mod" )
-            endif()
-        endforeach()
-    endif()
-endif()
-add_custom_target( lib DEPENDS magma )
+                get_filename_component(fmod ${filename} NAME_WE)
+                list(APPEND modules "${CMAKE_BINARY_DIR}/${fmod}.mod")
+            endif ()
+        endforeach ()
+    endif ()
+endif ()
+add_custom_target(lib DEPENDS magma)
 
 
 # ----------------------------------------
@@ -546,35 +557,35 @@ add_custom_target( lib DEPENDS magma )
 # If use fortran, compile only Fortran files, not magma_[sdcz]_no_fortran.cpp
 # else,           compile only C++     files, not Fortran files
 if (USE_FORTRAN)
-    foreach( filename ${liblapacktest_all} )
+    foreach (filename ${liblapacktest_all})
         if (filename MATCHES "\\.(f|f90|F90)$")
-            list( APPEND liblapacktest_all_f ${filename} )
-        endif()
-    endforeach()
-    add_library( lapacktest ${liblapacktest_all_f} )
-else()
+            list(APPEND liblapacktest_all_f ${filename})
+        endif ()
+    endforeach ()
+    add_library(lapacktest ${liblapacktest_all_f})
+else ()
     # alternatively, use only C/C++/CUDA files, including magma_[sdcz]_no_fortran.cpp
-    foreach( filename ${liblapacktest_all} )
+    foreach (filename ${liblapacktest_all})
         if (filename MATCHES "\\.(c|cu|cpp)$")
-            list( APPEND liblapacktest_all_cpp ${filename} )
-        endif()
-    endforeach()
-    add_library( lapacktest ${liblapacktest_all_cpp} )
-endif()
-target_link_libraries( lapacktest
-    ${blas_fix}
-    ${LAPACK_LIBRARIES}
+            list(APPEND liblapacktest_all_cpp ${filename})
+        endif ()
+    endforeach ()
+    add_library(lapacktest ${liblapacktest_all_cpp})
+endif ()
+target_link_libraries(lapacktest
+        ${blas_fix}
+        ${LAPACK_LIBRARIES}
 )
 
 
 # ----------------------------------------
 # compile tester library
-add_library( tester ${libtest_all} )
-target_link_libraries( tester
-    magma
-    lapacktest
-    ${blas_fix}
-    ${LAPACK_LIBRARIES}
+add_library(tester ${libtest_all})
+target_link_libraries(tester
+        magma
+        lapacktest
+        ${blas_fix}
+        ${LAPACK_LIBRARIES}
 )
 
 
@@ -583,38 +594,38 @@ target_link_libraries( tester
 
 # sparse doesn't have Fortran at the moment, so no need for above shenanigans
 if (MAGMA_ENABLE_CUDA)
-  include_directories( sparse/include )
-  include_directories( sparse/control )
-else()
-  include_directories( sparse_hip/include )
-  include_directories( sparse_hip/control )
-endif()
-include_directories( testing )
+    include_directories(sparse/include)
+    include_directories(sparse/control)
+else ()
+    include_directories(sparse_hip/include)
+    include_directories(sparse_hip/control)
+endif ()
+include_directories(testing)
 
 if (MAGMA_ENABLE_CUDA)
-  add_library( magma_sparse ${libsparse_all} )
+    add_library(magma_sparse ${libsparse_all})
   set_property(TARGET magma_sparse PROPERTY CUDA_STANDARD 14)
-  target_link_libraries( magma_sparse
-    magma
-    ${blas_fix}
-    ${LAPACK_LIBRARIES}
-    CUDA::cudart
-    CUDA::cublas
-    CUDA::cusparse
-    magma_nvcc_flags
+    target_link_libraries(magma_sparse
+            magma
+            ${blas_fix}
+            ${LAPACK_LIBRARIES}
+            CUDA::cudart
+            CUDA::cublas
+            CUDA::cusparse
+            magma_nvcc_flags
     )
-else()
-  add_library( magma_sparse ${libsparse_all} )
-  target_link_libraries( magma_sparse
-    magma
-    ${blas_fix}
-    ${LAPACK_LIBRARIES}
-    hip::device
-    roc::hipblas
-    roc::hipsparse
+else ()
+    add_library(magma_sparse ${libsparse_all})
+    target_link_libraries(magma_sparse
+            magma
+            ${blas_fix}
+            ${LAPACK_LIBRARIES}
+            hip::device
+            roc::hipblas
+            roc::hipsparse
     )
-endif()
-add_custom_target( sparse-lib DEPENDS magma_sparse )
+endif ()
+add_custom_target(sparse-lib DEPENDS magma_sparse)
 
 
 # ----------------------------------------
@@ -622,119 +633,119 @@ add_custom_target( sparse-lib DEPENDS magma_sparse )
 
 # save testers to testing/
 # save tester lib files to testing_lib/ to avoid cluttering lib/
-set( CMAKE_RUNTIME_OUTPUT_DIRECTORY testing )
-set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY testing_lib )
-set( CMAKE_LIBRARY_OUTPUT_DIRECTORY testing_lib )
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY testing)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY testing_lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY testing_lib)
 
 # skip Fortran testers, which require an extra file from CUDA
-foreach( filename ${testing_all} )
+foreach (filename ${testing_all})
     if (filename MATCHES "\\.(c|cu|cpp)$")
-        list( APPEND testing_all_cpp ${filename} )
-    endif()
-endforeach()
-foreach( TEST ${testing_all_cpp} )
-    string( REGEX REPLACE "\\.(cpp|f90|F90)" "" EXE ${TEST} )
-    string( REGEX REPLACE "testing/" "" EXE ${EXE} )
+        list(APPEND testing_all_cpp ${filename})
+    endif ()
+endforeach ()
+foreach (TEST ${testing_all_cpp})
+    string(REGEX REPLACE "\\.(cpp|f90|F90)" "" EXE ${TEST})
+    string(REGEX REPLACE "testing/" "" EXE ${EXE})
     #message( "${TEST} --> ${EXE}" )
-    add_executable( ${EXE} ${TEST} )
-    target_link_libraries( ${EXE} tester lapacktest magma )
-    list( APPEND testing ${EXE} )
-endforeach()
-add_custom_target( testing DEPENDS ${testing} )
+    add_executable(${EXE} ${TEST})
+    target_link_libraries(${EXE} tester lapacktest magma)
+    list(APPEND testing ${EXE})
+endforeach ()
+add_custom_target(testing DEPENDS ${testing})
 
 
 # ----------------------------------------
 # compile each sparse tester
 
 if (MAGMA_ENABLE_CUDA)
-  set(SPARSE_TEST_DIR "sparse/testing")
-else()
-  set(SPARSE_TEST_DIR "sparse_hip/testing")
-endif()
+    set(SPARSE_TEST_DIR "sparse/testing")
+else ()
+    set(SPARSE_TEST_DIR "sparse_hip/testing")
+endif ()
 
 
-set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SPARSE_TEST_DIR}" )
-cmake_policy( SET CMP0037 OLD)
-foreach( TEST ${sparse_testing_all} )
-    string( REGEX REPLACE "\\.(cpp|f90|F90)"     "" EXE ${TEST} )
-    string( REGEX REPLACE "${SPARSE_TEST_DIR}/" "" EXE ${EXE} )
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${SPARSE_TEST_DIR}")
+cmake_policy(SET CMP0037 OLD)
+foreach (TEST ${sparse_testing_all})
+    string(REGEX REPLACE "\\.(cpp|f90|F90)" "" EXE ${TEST})
+    string(REGEX REPLACE "${SPARSE_TEST_DIR}/" "" EXE ${EXE})
     #message( "${TEST} --> ${EXE}" )
-    add_executable( ${EXE} ${TEST} )
-    target_link_libraries( ${EXE} magma_sparse magma )
-    list( APPEND sparse-testing ${EXE} )
-endforeach()
-add_custom_target( sparse-testing DEPENDS ${sparse-testing} )
+    add_executable(${EXE} ${TEST})
+    target_link_libraries(${EXE} magma_sparse magma)
+    list(APPEND sparse-testing ${EXE})
+endforeach ()
+add_custom_target(sparse-testing DEPENDS ${sparse-testing})
 
 
 # ----------------------------------------
 # what to install
-install( TARGETS magma magma_sparse ${blas_fix}
-         RUNTIME DESTINATION bin
-         LIBRARY DESTINATION lib
-         ARCHIVE DESTINATION lib )
+install(TARGETS magma magma_sparse ${blas_fix}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 if (MAGMA_ENABLE_CUDA)
-  file( GLOB headers include/*.h sparse/include/*.h "${CMAKE_BINARY_DIR}/include/*.h" )
-else()
-  file( GLOB headers include/*.h sparse_hip/include/*.h "${CMAKE_BINARY_DIR}/include/*.h" )
-endif()
+    file(GLOB headers include/*.h sparse/include/*.h "${CMAKE_BINARY_DIR}/include/*.h")
+else ()
+    file(GLOB headers include/*.h sparse_hip/include/*.h "${CMAKE_BINARY_DIR}/include/*.h")
+endif ()
 if (USE_FORTRAN)
-    install( FILES ${headers} ${modules}
-             DESTINATION include )
-else()
-    install( FILES ${headers} DESTINATION include )
-endif()
+    install(FILES ${headers} ${modules}
+            DESTINATION include)
+else ()
+    install(FILES ${headers} DESTINATION include)
+endif ()
 
 # ----------------------------------------
 # pkg-config
 get_target_property(MAGMA_INCLUDE magma INCLUDE_DIRECTORIES)
-foreach(dir ${MAGMA_INCLUDE})
+foreach (dir ${MAGMA_INCLUDE})
     string(APPEND INCLUDE_COMPILER_STRING "-I${dir} ")
-endforeach()
-set( MAGMA_INCLUDE "${INCLUDE_COMPILER_STRING}" )
-set( pkgconfig lib/pkgconfig/magma.pc )
-message( STATUS "pkgconfig ${pkgconfig}" )
-set( INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" )
-set( CFLAGS "${CMAKE_C_FLAGS}" )
-set( CXXFLAGS "${CMAKE_CXX_FLAGS}" )
+endforeach ()
+set(MAGMA_INCLUDE "${INCLUDE_COMPILER_STRING}")
+set(pkgconfig lib/pkgconfig/magma.pc)
+message(STATUS "pkgconfig ${pkgconfig}")
+set(INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+set(CFLAGS "${CMAKE_C_FLAGS}")
+set(CXXFLAGS "${CMAKE_CXX_FLAGS}")
 # CMake finds the Accelerate directory; we want -framework Accelerate for linking.
-string( REPLACE "/System/Library/Frameworks/Accelerate.framework" "-framework Accelerate" LAPACK_LIBS "${LAPACK_LIBRARIES}" )
+string(REPLACE "/System/Library/Frameworks/Accelerate.framework" "-framework Accelerate" LAPACK_LIBS "${LAPACK_LIBRARIES}")
 if (MAGMA_ENABLE_CUDA)
-  string( REPLACE ";" " " LIBS
-    "${blas_fix_lib} ${LAPACK_LIBS} -L${CUDAToolkit_LIBRARY_DIR} -lcudart -lcublas -lcusparse")
-else()
-  string( REPLACE ";" " " LIBS
-     "${blas_fix_lib} ${LAPACK_LIBS} ${HIP} ${rocBLAS} ${rocSPARSE}" )
-#    "${blas_fix_lib} ${LAPACK_LIBS} hip::device roc::hipblas roc::hipsparse" )
-endif()
-set( MAGMA_REQUIRED "" )
-configure_file( "${pkgconfig}.in" "${pkgconfig}" @ONLY )
-install( FILES "${CMAKE_BINARY_DIR}/${pkgconfig}"
-         DESTINATION lib/pkgconfig )
+    string(REPLACE ";" " " LIBS
+            "${blas_fix_lib} ${LAPACK_LIBS} -L${CUDAToolkit_LIBRARY_DIR} -lcudart -lcublas -lcusparse")
+else ()
+    string(REPLACE ";" " " LIBS
+            "${blas_fix_lib} ${LAPACK_LIBS} ${HIP} ${rocBLAS} ${rocSPARSE}")
+    #    "${blas_fix_lib} ${LAPACK_LIBS} hip::device roc::hipblas roc::hipsparse" )
+endif ()
+set(MAGMA_REQUIRED "")
+configure_file("${pkgconfig}.in" "${pkgconfig}" @ONLY)
+install(FILES "${CMAKE_BINARY_DIR}/${pkgconfig}"
+        DESTINATION lib/pkgconfig)
 
 # ----------------------------------------
-get_directory_property( compile_definitions COMPILE_DEFINITIONS )
+get_directory_property(compile_definitions COMPILE_DEFINITIONS)
 
-message( STATUS "Flags" )
-message( STATUS "    CMAKE_INSTALL_PREFIX:  ${CMAKE_INSTALL_PREFIX}" )
-message( STATUS "    CFLAGS:                ${CMAKE_C_FLAGS}" )
-message( STATUS "    CXXFLAGS:              ${CMAKE_CXX_FLAGS}" )
+message(STATUS "Flags")
+message(STATUS "    CMAKE_INSTALL_PREFIX:  ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "    CFLAGS:                ${CMAKE_C_FLAGS}")
+message(STATUS "    CXXFLAGS:              ${CMAKE_CXX_FLAGS}")
 if (MAGMA_ENABLE_CUDA)
-  message( STATUS "    NVCCFLAGS:             ${CMAKE_CUDA_FLAGS}" )
-else()
-  message( STATUS "    DEVCCFLAGS:            ${DEVCCFLAGS}" )
-endif()
-message( STATUS "    FFLAGS:                ${CMAKE_Fortran_FLAGS}" )
-message( STATUS "    LIBS:                  ${LIBS}" )
-message( STATUS "    blas_fix:              ${blas_fix}  (MacOS Accelerate only)" )
-message( STATUS "    LAPACK_LIBRARIES:      ${LAPACK_LIBRARIES}"      )
-message( STATUS "    INCLUDE_DIRECTORIES:   ${MAGMA_INCLUDE}"   )
+    message(STATUS "    NVCCFLAGS:             ${CMAKE_CUDA_FLAGS}")
+else ()
+    message(STATUS "    DEVCCFLAGS:            ${DEVCCFLAGS}")
+endif ()
+message(STATUS "    FFLAGS:                ${CMAKE_Fortran_FLAGS}")
+message(STATUS "    LIBS:                  ${LIBS}")
+message(STATUS "    blas_fix:              ${blas_fix}  (MacOS Accelerate only)")
+message(STATUS "    LAPACK_LIBRARIES:      ${LAPACK_LIBRARIES}")
+message(STATUS "    INCLUDE_DIRECTORIES:   ${MAGMA_INCLUDE}")
 if (MAGMA_ENABLE_CUDA)
-  message( STATUS "    CUDA_CUDART_LIBRARY:   CUDA::cudart"   )
-  message( STATUS "    CUDA_CUBLAS_LIBRARIES: CUDA::cublas" )
-  message( STATUS "    CUDA_cusparse_LIBRARY: CUDA::cusparse" )
-else()
-  message( STATUS "    HIP_LIBRARY:   hip::device"   )
-  message( STATUS "    HIP_BLAS_LIBRARIES: roc::hipblas" )
-  message( STATUS "    HIP_sparse_LIBRARY: roc::hipsparse" )
-endif()
-message( STATUS "    Fortran modules:       ${modules}" )
+    message(STATUS "    CUDA_CUDART_LIBRARY:   CUDA::cudart")
+    message(STATUS "    CUDA_CUBLAS_LIBRARIES: CUDA::cublas")
+    message(STATUS "    CUDA_cusparse_LIBRARY: CUDA::cusparse")
+else ()
+    message(STATUS "    HIP_LIBRARY:   hip::device")
+    message(STATUS "    HIP_BLAS_LIBRARIES: roc::hipblas")
+    message(STATUS "    HIP_sparse_LIBRARY: roc::hipsparse")
+endif ()
+message(STATUS "    Fortran modules:       ${modules}")

--- a/include/magma_auxiliary.h
+++ b/include/magma_auxiliary.h
@@ -82,6 +82,9 @@ magma_int_t
 magma_malloc( magma_ptr *ptr_ptr, size_t bytes );
 
 magma_int_t
+magma_malloc_async( magma_ptr* ptrPtr, size_t size, magma_queue_t queue);
+
+magma_int_t
 magma_malloc_cpu( void **ptr_ptr, size_t bytes );
 
 magma_int_t
@@ -93,6 +96,9 @@ magma_free_cpu( void *ptr );
 #define magma_free( ptr ) \
         magma_free_internal( ptr, __func__, __FILE__, __LINE__ )
 
+#define magma_free_async( ptr, queue ) \
+        magma_free_internal_async( ptr, __func__, __FILE__, __LINE__, queue )
+
 #define magma_free_pinned( ptr ) \
         magma_free_pinned_internal( ptr, __func__, __FILE__, __LINE__ )
 
@@ -100,6 +106,11 @@ magma_int_t
 magma_free_internal(
     magma_ptr ptr,
     const char* func, const char* file, int line );
+
+magma_int_t
+magma_free_internal_async(
+    magma_ptr ptr,
+    const char* func, const char* file, int line, magma_queue_t queue );
 
 magma_int_t
 magma_free_pinned_internal(
@@ -128,23 +139,44 @@ magma_memset_async(void * ptr, int value, size_t count, magma_queue_t queue);
 /// Type-safe version of magma_malloc(), for magma_int_t arrays. Allocates n*sizeof(magma_int_t) bytes.
 static inline magma_int_t magma_imalloc( magmaInt_ptr           *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(magma_int_t)        ); }
 
+/// Type-safe version of magma_malloc(), for magma_int_t arrays. Allocates n*sizeof(magma_int_t) bytes.
+static inline magma_int_t magma_imalloc_async( magmaInt_ptr           *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(magma_int_t), queue ); }
+
 /// Type-safe version of magma_malloc(), for magma_index_t arrays. Allocates n*sizeof(magma_index_t) bytes.
 static inline magma_int_t magma_index_malloc( magmaIndex_ptr    *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(magma_index_t)      ); }
+
+/// Type-safe version of magma_malloc(), for magma_index_t arrays. Allocates n*sizeof(magma_index_t) bytes.
+static inline magma_int_t magma_index_malloc_async( magmaIndex_ptr    *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(magma_index_t), queue ); }
 
 /// Type-safe version of magma_malloc(), for magma_uindex_t arrays. Allocates n*sizeof(magma_uindex_t) bytes.
 static inline magma_int_t magma_uindex_malloc( magmaUIndex_ptr    *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(magma_uindex_t)      ); }
 
+/// Type-safe version of magma_malloc(), for magma_uindex_t arrays. Allocates n*sizeof(magma_uindex_t) bytes.
+static inline magma_int_t magma_uindex_malloc_async( magmaUIndex_ptr    *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(magma_uindex_t), queue); }
+
 /// Type-safe version of magma_malloc(), for float arrays. Allocates n*sizeof(float) bytes.
 static inline magma_int_t magma_smalloc( magmaFloat_ptr         *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(float)              ); }
+
+/// Type-safe version of magma_malloc(), for float arrays. Allocates n*sizeof(float) bytes.
+static inline magma_int_t magma_smalloc_async( magmaFloat_ptr         *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(float), queue); }
 
 /// Type-safe version of magma_malloc(), for double arrays. Allocates n*sizeof(double) bytes.
 static inline magma_int_t magma_dmalloc( magmaDouble_ptr        *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(double)             ); }
 
+/// Type-safe version of magma_malloc(), for double arrays. Allocates n*sizeof(double) bytes.
+static inline magma_int_t magma_dmalloc_async( magmaDouble_ptr        *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(double), queue); }
+
 /// Type-safe version of magma_malloc(), for magmaFloatComplex arrays. Allocates n*sizeof(magmaFloatComplex) bytes.
 static inline magma_int_t magma_cmalloc( magmaFloatComplex_ptr  *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(magmaFloatComplex)  ); }
 
+/// Type-safe version of magma_malloc(), for magmaFloatComplex arrays. Allocates n*sizeof(magmaFloatComplex) bytes.
+static inline magma_int_t magma_cmalloc_async( magmaFloatComplex_ptr  *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(magmaFloatComplex), queue ); }
+
 /// Type-safe version of magma_malloc(), for magmaDoubleComplex arrays. Allocates n*sizeof(magmaDoubleComplex) bytes.
 static inline magma_int_t magma_zmalloc( magmaDoubleComplex_ptr *ptr_ptr, size_t n ) { return magma_malloc( (magma_ptr*) ptr_ptr, n*sizeof(magmaDoubleComplex) ); }
+
+/// Type-safe version of magma_malloc_async(), for magmaDoubleComplex arrays. Allocates n*sizeof(magmaDoubleComplex) bytes.
+static inline magma_int_t magma_zmalloc_async( magmaDoubleComplex_ptr *ptr_ptr, size_t n, magma_queue_t queue ) { return magma_malloc_async( (magma_ptr*) ptr_ptr, n*sizeof(magmaDoubleComplex), queue ); }
 
 /// @}
 

--- a/include/magma_z.h
+++ b/include/magma_z.h
@@ -507,6 +507,16 @@ magma_zgerbt_gpu(
 
 // CUDA MAGMA only
 magma_int_t
+magma_zgerbt_gpu_async(
+        const magma_bool_t gen, const magma_int_t n, const magma_int_t nrhs,
+        magmaDoubleComplex_ptr const dA, magma_int_t const ldda,
+        magmaDoubleComplex_ptr const dB, magma_int_t const lddb,
+        magmaDoubleComplex_ptr const dU, magmaDoubleComplex_ptr const dV,
+        magma_int_t *info,
+        magma_queue_t queue);
+
+// CUDA MAGMA only
+magma_int_t
 magma_zgerfs_nopiv_gpu(
     magma_trans_t trans, magma_int_t n, magma_int_t nrhs,
     magmaDoubleComplex_ptr dA, magma_int_t ldda,
@@ -515,6 +525,20 @@ magma_zgerfs_nopiv_gpu(
     magmaDoubleComplex_ptr dworkd, magmaDoubleComplex_ptr dAF,
     magma_int_t *iter,
     magma_int_t *info);
+
+// CUDA MAGMA only
+magma_int_t
+magma_zgerfs_nopiv_gpu_async(
+        magma_trans_t trans, magma_int_t n, magma_int_t nrhs,
+        magmaDoubleComplex_ptr dA, magma_int_t ldda,
+        magmaDoubleComplex_ptr dB, magma_int_t lddb,
+        magmaDoubleComplex_ptr dX, magma_int_t lddx,
+        magmaDoubleComplex_ptr dworkd, magmaDoubleComplex_ptr dAF,
+        magma_int_t *iter,
+        magma_int_t *info,
+        magma_int_t iter_max,
+        double bwdmax,
+        magma_queue_t queue);
 
 magma_int_t
 magma_zgesdd(
@@ -553,6 +577,13 @@ magma_zgesv_nopiv_gpu(
     magmaDoubleComplex_ptr dB, magma_int_t lddb,
     magma_int_t *info);
 
+magma_int_t
+magma_zgesv_nopiv_gpu_async(
+        magma_int_t n, magma_int_t nrhs,
+        magmaDoubleComplex_ptr dA, magma_int_t ldda,
+        magmaDoubleComplex_ptr dB, magma_int_t lddb,
+        magma_int_t *info, magma_queue_t queue );
+
 // CUDA MAGMA only
 magma_int_t
 magma_zgesv_rbt(
@@ -560,6 +591,26 @@ magma_zgesv_rbt(
     magmaDoubleComplex *A, magma_int_t lda,
     magmaDoubleComplex *B, magma_int_t ldb,
     magma_int_t *info);
+
+// CUDA MAGMA only
+magma_int_t
+magma_zgesv_rbt_async(
+        const magma_bool_t refine, const magma_int_t n, const magma_int_t nrhs,
+        const magmaDoubleComplex *const dA, const magma_int_t lda,
+        magmaDoubleComplex *const dB, const magma_int_t ldb,
+        magma_int_t *info,
+        const magma_int_t iter_max, const double bwdmax,
+        magma_queue_t queue );
+
+// CUDA MAGMA only
+magma_int_t
+magma_zgesv_rbt_refine_async(
+        const magma_int_t n, const magma_int_t nrhs,
+        const magmaDoubleComplex *const dA_, const magma_int_t lda,
+        magmaDoubleComplex *const dB_, const magma_int_t ldb,
+        magma_int_t *info,
+        const magma_int_t iter_max, const double bwdmax,
+        magma_queue_t queue);
 
 magma_int_t
 magma_zgesvd(
@@ -705,6 +756,13 @@ magma_zgetrf_nopiv_gpu(
     magma_int_t *info);
 
 magma_int_t
+magma_zgetrf_nopiv_gpu_async(
+        magma_int_t m, magma_int_t n,
+        magmaDoubleComplex_ptr dA, magma_int_t ldda,
+        magma_int_t *info,
+        magma_queue_t queue);
+
+magma_int_t
 magma_zgetri_gpu(
     magma_int_t n,
     magmaDoubleComplex_ptr dA, magma_int_t ldda,
@@ -748,6 +806,13 @@ magma_zgetrs_nopiv_gpu(
     magmaDoubleComplex_ptr dA, magma_int_t ldda,
     magmaDoubleComplex_ptr dB, magma_int_t lddb,
     magma_int_t *info);
+
+magma_int_t
+magma_zgetrs_nopiv_gpu_async(
+        magma_trans_t trans, magma_int_t n, magma_int_t nrhs,
+        magmaDoubleComplex_ptr dA, magma_int_t ldda,
+        magmaDoubleComplex_ptr dB, magma_int_t lddb,
+        magma_int_t *info, magma_queue_t queue);
 
 // ------------------------------------------------------------ zhe routines
 magma_int_t

--- a/include/magmablas_z.h
+++ b/include/magmablas_z.h
@@ -496,6 +496,13 @@ magmablas_ztrtri_diag(
     magmaDoubleComplex_ptr d_dinvA,
     magma_queue_t queue );
 
+void
+magmablas_ztrtri_diag_async(
+    magma_uplo_t uplo, magma_diag_t diag, magma_int_t n,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr d_dinvA,
+    magma_queue_t queue );
+
   /*
    * to cleanup (alphabetical order)
    */
@@ -750,6 +757,15 @@ magmablas_zgemm_reduce(
 
 void
 magmablas_ztrsm(
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t transA, magma_diag_t diag,
+    magma_int_t m, magma_int_t n,
+    magmaDoubleComplex alpha,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr       dB, magma_int_t lddb,
+    magma_queue_t queue );
+
+void
+magmablas_ztrsm_async(
     magma_side_t side, magma_uplo_t uplo, magma_trans_t transA, magma_diag_t diag,
     magma_int_t m, magma_int_t n,
     magmaDoubleComplex alpha,

--- a/interface_cuda/alloc.cpp
+++ b/interface_cuda/alloc.cpp
@@ -23,6 +23,7 @@
 #include "error.h"
 
 //#ifdef MAGMA_HAVE_CUDA
+#define NOPINNED_ALLOC // Fix for multi GPU systems running jemalloc, where cudaHostAlloc and cudaHostRegister kill parallelism across multiple threads using multiple GPUs
 
 
 #ifdef DEBUG_MEMORY
@@ -78,6 +79,53 @@ magma_malloc( magma_ptr* ptrPtr, size_t size )
 
 
 /***************************************************************************//**
+    Allocates memory on the GPU. CUDA imposes a synchronization.
+    Use magma_free() to free this memory.
+
+    @param[out]
+    ptrPtr  On output, set to the pointer that was allocated.
+            NULL on failure.
+
+    @param[in]
+    size    Size in bytes to allocate. If size = 0, allocates some minimal size.
+
+     @param[in]
+    queue    Magma queue whose CUDA stream is used to put the cudaMalloc on.
+
+    @return MAGMA_SUCCESS
+    @return MAGMA_ERR_DEVICE_ALLOC on failure
+
+    Type-safe versions avoid the need for a (void**) cast and explicit sizeof.
+    @see magma_smalloc_q
+    @see magma_dmalloc_q
+    @see magma_cmalloc_q
+    @see magma_zmalloc_q
+    @see magma_imalloc_q
+    @see magma_index_malloc_q
+
+    @ingroup magma_malloc
+*******************************************************************************/
+extern "C" magma_int_t
+magma_malloc_async( magma_ptr* ptrPtr, size_t size, magma_queue_t queue)
+{
+    // malloc and free sometimes don't work for size=0, so allocate some minimal size
+    if ( size == 0 )
+        size = sizeof(magmaDoubleComplex);
+    if ( cudaSuccess != cudaMallocAsync( ptrPtr, size, queue->cuda_stream() )) {
+        return MAGMA_ERR_DEVICE_ALLOC;
+    }
+
+    #ifdef DEBUG_MEMORY
+    g_pointers_mutex.lock();
+    g_pointers_dev[ *ptrPtr ] = size;
+    g_pointers_mutex.unlock();
+    #endif
+
+    return MAGMA_SUCCESS;
+}
+
+
+/***************************************************************************//**
     @fn magma_free( ptr )
 
     Frees GPU memory previously allocated by magma_malloc().
@@ -106,6 +154,45 @@ magma_free_internal( magma_ptr ptr,
     #endif
 
     cudaError_t err = cudaFree( ptr );
+    check_xerror( err, func, file, line );
+    if ( err != cudaSuccess ) {
+        return MAGMA_ERR_INVALID_PTR;
+    }
+    return MAGMA_SUCCESS;
+}
+
+
+/***************************************************************************//**
+    @fn magma_free( ptr )
+
+    Frees GPU memory previously allocated by magma_malloc().
+
+    @param[in]
+    ptr     Pointer to free.
+    @param[in]
+    queue   MAGMA queue to use the CYDA stream to free on.
+
+    @return MAGMA_SUCCESS
+    @return MAGMA_ERR_INVALID_PTR on failure
+
+    @ingroup magma_malloc
+*******************************************************************************/
+extern "C" magma_int_t
+magma_free_internal_async( magma_ptr ptr,
+    const char* func, const char* file, int line, magma_queue_t queue )
+{
+    #ifdef DEBUG_MEMORY
+    g_pointers_mutex.lock();
+    if ( ptr != NULL && g_pointers_dev.count( ptr ) == 0 ) {
+        fprintf( stderr, "magma_free( %p ) that wasn't allocated with magma_malloc.\n", ptr );
+    }
+    else {
+        g_pointers_dev.erase( ptr );
+    }
+    g_pointers_mutex.unlock();
+    #endif
+
+    cudaError_t err = cudaFreeAsync( ptr, queue->cuda_stream() );
     check_xerror( err, func, file, line );
     if ( err != cudaSuccess ) {
         return MAGMA_ERR_INVALID_PTR;
@@ -162,10 +249,10 @@ magma_malloc_cpu( void** ptrPtr, size_t size )
     }
 #endif
 #else
-    *ptrPtr = malloc( size );
-    if ( *ptrPtr == NULL ) {
-        return MAGMA_ERR_HOST_ALLOC;
-    }
+        *ptrPtr = malloc( size );
+        if ( *ptrPtr == NULL ) {
+            return MAGMA_ERR_HOST_ALLOC;
+        }
 #endif
 
     #ifdef DEBUG_MEMORY
@@ -242,10 +329,15 @@ magma_free_cpu( void* ptr )
 extern "C" magma_int_t
 magma_malloc_pinned( void** ptrPtr, size_t size )
 {
+    #ifdef NOPINNED_ALLOC
+    return magma_malloc_cpu( ptrPtr, size );
+    #endif
+
     // malloc and free sometimes don't work for size=0, so allocate some minimal size
     // (for pinned memory, the error is detected in free)
     if ( size == 0 )
         size = sizeof(magmaDoubleComplex);
+
     if ( cudaSuccess != cudaHostAlloc( ptrPtr, size, cudaHostAllocPortable )) {
         return MAGMA_ERR_HOST_ALLOC;
     }
@@ -277,6 +369,10 @@ extern "C" magma_int_t
 magma_free_pinned_internal( void* ptr,
     const char* func, const char* file, int line )
 {
+    #ifdef NOPINNED_ALLOC
+    return magma_free_cpu( ptr );
+    #endif
+
     #ifdef DEBUG_MEMORY
     g_pointers_mutex.lock();
     if ( ptr != NULL && g_pointers_pin.count( ptr ) == 0 ) {
@@ -293,6 +389,7 @@ magma_free_pinned_internal( void* ptr,
     if ( cudaSuccess != err ) {
         return MAGMA_ERR_INVALID_PTR;
     }
+
     return MAGMA_SUCCESS;
 }
 

--- a/magmablas/ztrsm.cu
+++ b/magmablas/ztrsm.cu
@@ -380,6 +380,244 @@ void magmablas_ztrsm_outofplace(
     }
 }
 
+extern "C"
+void magmablas_ztrsm_outofplace_async(
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t transA, magma_diag_t diag,
+    magma_int_t m, magma_int_t n,
+    magmaDoubleComplex alpha,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr       dB, magma_int_t lddb,
+    magmaDoubleComplex_ptr       dX, magma_int_t lddx,
+    magma_int_t flag,
+    magmaDoubleComplex_ptr d_dinvA, magma_int_t dinvA_length,
+    magma_queue_t queue )
+{
+    #define dA(i_, j_) (dA + (i_) + (j_)*ldda)
+    #define dB(i_, j_) (dB + (i_) + (j_)*lddb)
+    #define dX(i_, j_) (dX + (i_) + (j_)*lddx)
+    #define d_dinvA(i_) (d_dinvA + (i_)*NB)
+
+    const magmaDoubleComplex c_neg_one = MAGMA_Z_NEG_ONE;
+    const magmaDoubleComplex c_one     = MAGMA_Z_ONE;
+    const magmaDoubleComplex c_zero    = MAGMA_Z_ZERO;
+
+    magma_int_t i, jb;
+    magma_int_t nrowA = (side == MagmaLeft ? m : n);
+
+    magma_int_t min_dinvA_length;
+    if ( side == MagmaLeft ) {
+        min_dinvA_length = magma_roundup( m, NB )*NB;
+    }
+    else {
+        min_dinvA_length = magma_roundup( n, NB )*NB;
+    }
+
+    magma_int_t info = 0;
+    if ( side != MagmaLeft && side != MagmaRight ) {
+        info = -1;
+    } else if ( uplo != MagmaUpper && uplo != MagmaLower ) {
+        info = -2;
+    } else if ( transA != MagmaNoTrans && transA != MagmaTrans && transA != MagmaConjTrans ) {
+        info = -3;
+    } else if ( diag != MagmaUnit && diag != MagmaNonUnit ) {
+        info = -4;
+    } else if (m < 0) {
+        info = -5;
+    } else if (n < 0) {
+        info = -6;
+    } else if (dA == NULL) {
+        info = -8;
+    } else if (ldda < max(1,nrowA)) {
+        info = -9;
+    } else if (dB == NULL) {
+        info = -10;
+    } else if (lddb < max(1,m)) {
+        info = -11;
+    } else if (dX == NULL) {
+        info = -12;
+    } else if (lddx < max(1,m)) {
+        info = -13;
+    } else if (d_dinvA == NULL) {
+        info = -15;
+    } else if (dinvA_length < min_dinvA_length) {
+        info = -16;
+    }
+
+    if (info != 0) {
+        magma_xerbla( __func__, -(info) );
+        return;
+    }
+
+    // quick return if possible.
+    if (m == 0 || n == 0)
+        return;
+
+    if (side == MagmaLeft) {
+        // invert diagonal blocks
+        if (flag)
+            magmablas_ztrtri_diag_async( uplo, diag, m, dA, ldda, d_dinvA, queue );
+
+        if (transA == MagmaNoTrans) {
+            if (uplo == MagmaLower) {
+                // left, lower no-transpose
+                // handle first block separately with alpha
+                jb = min(NB, m);
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans, jb, n, jb, alpha, d_dinvA(0), NB, dB, lddb, c_zero, dX, lddx, queue );
+                if (NB < m) {
+                    magma_zgemm( MagmaNoTrans, MagmaNoTrans, m-NB, n, NB, c_neg_one, dA(NB,0), ldda, dX, lddx, alpha, dB(NB,0), lddb, queue );
+
+                    // remaining blocks
+                    for( i=NB; i < m; i += NB ) {
+                        jb = min(m-i, NB);
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, jb, n, jb, c_one, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                        if (i+NB >= m)
+                            break;
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, m-i-NB, n, NB, c_neg_one, dA(i+NB,i), ldda, dX(i,0), lddx, c_one, dB(i+NB,0), lddb, queue );
+                    }
+                }
+            }
+            else {
+                // left, upper no-transpose
+                // handle first block separately with alpha
+                jb = (m % NB == 0) ? NB : (m % NB);
+                i = m-jb;
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans, jb, n, jb, alpha, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                if (i-NB >= 0) {
+                    magma_zgemm( MagmaNoTrans, MagmaNoTrans, i, n, jb, c_neg_one, dA(0,i), ldda, dX(i,0), lddx, alpha, dB, lddb, queue );
+
+                    // remaining blocks
+                    for( i=m-jb-NB; i >= 0; i -= NB ) {
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, NB, n, NB, c_one, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                        if (i-NB < 0)
+                            break;
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, i, n, NB, c_neg_one, dA(0,i), ldda, dX(i,0), lddx, c_one, dB, lddb, queue );
+                    }
+                }
+            }
+        }
+        else {  // transA == MagmaTrans || transA == MagmaConjTrans
+            if (uplo == MagmaLower) {
+                // left, lower transpose
+                // handle first block separately with alpha
+                jb = (m % NB == 0) ? NB : (m % NB);
+                i = m-jb;
+                magma_zgemm( transA, MagmaNoTrans, jb, n, jb, alpha, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                if (i-NB >= 0) {
+                    magma_zgemm( transA, MagmaNoTrans, i, n, jb, c_neg_one, dA(i,0), ldda, dX(i,0), lddx, alpha, dB, lddb, queue );
+
+                    // remaining blocks
+                    for( i=m-jb-NB; i >= 0; i -= NB ) {
+                        magma_zgemm( transA, MagmaNoTrans, NB, n, NB, c_one, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                        if (i-NB < 0)
+                            break;
+                        magma_zgemm( transA, MagmaNoTrans, i, n, NB, c_neg_one, dA(i,0), ldda, dX(i,0), lddx, c_one, dB, lddb, queue );
+                    }
+                }
+            }
+            else {
+                // left, upper transpose
+                // handle first block separately with alpha
+                jb = min(NB, m);
+                magma_zgemm( transA, MagmaNoTrans, jb, n, jb, alpha, d_dinvA(0), NB, dB, lddb, c_zero, dX, lddx, queue );
+                if (NB < m) {
+                    magma_zgemm( transA, MagmaNoTrans, m-NB, n, NB, c_neg_one, dA(0,NB), ldda, dX, lddx, alpha, dB(NB,0), lddb, queue );
+
+                    // remaining blocks
+                    for( i=NB; i < m; i += NB ) {
+                        jb = min(m-i, NB);
+                        magma_zgemm( transA, MagmaNoTrans, jb, n, jb, c_one, d_dinvA(i), NB, dB(i,0), lddb, c_zero, dX(i,0), lddx, queue );
+                        if (i+NB >= m)
+                            break;
+                        magma_zgemm( transA, MagmaNoTrans, m-i-NB, n, NB, c_neg_one, dA(i,i+NB), ldda, dX(i,0), lddx, c_one, dB(i+NB,0), lddb, queue );
+                    }
+                }
+            }
+        }
+    }
+    else {  // side == MagmaRight
+        // invert diagonal blocks
+        if (flag)
+            magmablas_ztrtri_diag_async( uplo, diag, n, dA, ldda, d_dinvA, queue );
+
+        if (transA == MagmaNoTrans) {
+            if (uplo == MagmaLower) {
+                // right, lower no-transpose
+                // handle first block separately with alpha
+                jb = (n % NB == 0) ? NB : (n % NB);
+                i = n-jb;
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, jb, jb, alpha, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                if (i-NB >= 0) {
+                    magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, i, jb, c_neg_one, dX(0,i), lddx, dA(i,0), ldda, alpha, dB, lddb, queue );
+
+                    // remaining blocks
+                    for( i=n-jb-NB; i >= 0; i -= NB ) {
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, NB, NB, c_one, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                        if (i-NB < 0)
+                            break;
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, i, NB, c_neg_one, dX(0,i), lddx, dA(i,0), ldda, c_one, dB, lddb, queue );
+                    }
+                }
+            }
+            else {
+                // right, upper no-transpose
+                // handle first block separately with alpha
+                jb = min(NB, n);
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, jb, jb, alpha, dB, lddb, d_dinvA(0), NB, c_zero, dX, lddx, queue );
+                if (NB < n) {
+                    magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, n-NB, NB, c_neg_one, dX, lddx, dA(0,NB), ldda, alpha, dB(0,NB), lddb, queue );
+
+                    // remaining blocks
+                    for( i=NB; i < n; i += NB ) {
+                        jb = min(NB, n-i);
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, jb, jb, c_one, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                        if (i+NB >= n)
+                            break;
+                        magma_zgemm( MagmaNoTrans, MagmaNoTrans, m, n-i-NB, NB, c_neg_one, dX(0,i), lddx, dA(i,i+NB), ldda, c_one, dB(0,i+NB), lddb, queue );
+                    }
+                }
+            }
+        }
+        else { // transA == MagmaTrans || transA == MagmaConjTrans
+            if (uplo == MagmaLower) {
+                // right, lower transpose
+                // handle first block separately with alpha
+                jb = min(NB, n);
+                magma_zgemm( MagmaNoTrans, transA, m, jb, jb, alpha, dB, lddb, d_dinvA(0), NB, c_zero, dX, lddx, queue );
+                if (NB < n) {
+                    magma_zgemm( MagmaNoTrans, transA, m, n-NB, NB, c_neg_one, dX, lddx, dA(NB,0), ldda, alpha, dB(0,NB), lddb, queue );
+
+                    // remaining blocks
+                    for( i=NB; i < n; i += NB ) {
+                        jb = min(NB, n-i);
+                        magma_zgemm( MagmaNoTrans, transA, m, jb, jb, c_one, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                        if (i+NB >= n)
+                            break;
+                        magma_zgemm( MagmaNoTrans, transA, m, n-i-NB, NB, c_neg_one, dX(0,i), lddx, dA(NB+i,i), ldda, c_one, dB(0,i+NB), lddb, queue );
+                    }
+                }
+            }
+            else {
+                // right, upper transpose
+                // handle first block separately with alpha
+                jb = (n % NB == 0) ? NB : (n % NB);
+                i = n-jb;
+                magma_zgemm( MagmaNoTrans, transA, m, jb, jb, alpha, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                if (i-NB >= 0) {
+                    magma_zgemm( MagmaNoTrans, transA, m, i, jb, c_neg_one, dX(0,i), lddx, dA(0,i), ldda, alpha, dB, lddb, queue );
+
+                    // remaining blocks
+                    for( i=n-jb-NB; i >= 0; i -= NB ) {
+                        magma_zgemm( MagmaNoTrans, transA, m, NB, NB, c_one, dB(0,i), lddb, d_dinvA(i), NB, c_zero, dX(0,i), lddx, queue );
+                        if (i-NB < 0)
+                            break;
+                        magma_zgemm( MagmaNoTrans, transA, m, i, NB, c_neg_one, dX(0,i), lddx, dA(0,i), ldda, c_one, dB, lddb, queue );
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 /***************************************************************************//**
     Similar to magmablas_ztrsm_outofplace(), but copies result dX back to dB,
@@ -401,6 +639,25 @@ void magmablas_ztrsm_work(
     magma_queue_t queue )
 {
     magmablas_ztrsm_outofplace( side, uplo, transA, diag, m, n, alpha,
+                                  dA, ldda, dB, lddb, dX, lddx, flag,
+                                  d_dinvA, dinvA_length, queue );
+    // copy X to B
+    magmablas_zlacpy( MagmaFull, m, n, dX, lddx, dB, lddb, queue );
+}
+
+extern "C"
+void magmablas_ztrsm_work_async(
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t transA, magma_diag_t diag,
+    magma_int_t m, magma_int_t n,
+    magmaDoubleComplex alpha,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr       dB, magma_int_t lddb,
+    magmaDoubleComplex_ptr       dX, magma_int_t lddx,
+    magma_int_t flag,
+    magmaDoubleComplex_ptr d_dinvA, magma_int_t dinvA_length,
+    magma_queue_t queue )
+{
+    magmablas_ztrsm_outofplace_async( side, uplo, transA, diag, m, n, alpha,
                                   dA, ldda, dB, lddb, dX, lddx, flag,
                                   d_dinvA, dinvA_length, queue );
     // copy X to B
@@ -483,4 +740,73 @@ void magmablas_ztrsm(
 
     magma_free( d_dinvA );
     magma_free( dX );
+}
+
+extern "C"
+void magmablas_ztrsm_async(
+    magma_side_t side, magma_uplo_t uplo, magma_trans_t transA, magma_diag_t diag,
+    magma_int_t m, magma_int_t n,
+    magmaDoubleComplex alpha,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr       dB, magma_int_t lddb,
+    magma_queue_t queue )
+{
+    const magma_int_t nrowA = (side == MagmaLeft ? m : n);
+
+    magma_int_t info = 0;
+    if ( side != MagmaLeft && side != MagmaRight ) {
+        info = -1;
+    } else if ( uplo != MagmaUpper && uplo != MagmaLower ) {
+        info = -2;
+    } else if ( transA != MagmaNoTrans && transA != MagmaTrans && transA != MagmaConjTrans ) {
+        info = -3;
+    } else if ( diag != MagmaUnit && diag != MagmaNonUnit ) {
+        info = -4;
+    } else if (m < 0) {
+        info = -5;
+    } else if (n < 0) {
+        info = -6;
+    } else if (dA == NULL) {
+        info = -8;
+    } else if (ldda < max(1,nrowA)) {
+        info = -9;
+    } else if (dB == NULL) {
+        info = -10;
+    } else if (lddb < max(1,m)) {
+        info = -11;
+    }
+
+    if (info != 0) {
+        magma_xerbla( __func__, -(info) );
+        return;
+    }
+
+    magmaDoubleComplex_ptr d_dinvA=NULL, dX=NULL;
+    const magma_int_t lddx = magma_roundup( m, 32 );
+    const magma_int_t size_x = lddx*n;
+    magma_int_t dinvA_length;
+    if ( side == MagmaLeft ) {
+        dinvA_length = magma_roundup( m, NB )*NB;
+    }
+    else {
+        dinvA_length = magma_roundup( n, NB )*NB;
+    }
+
+    magma_zmalloc_async( &d_dinvA, dinvA_length, queue );
+    magma_zmalloc_async( &dX, size_x, queue );
+
+    if ( d_dinvA == NULL || dX == NULL ) {
+        info = MAGMA_ERR_DEVICE_ALLOC;
+        magma_xerbla( __func__, -(info) );
+        // continue to free
+    }
+    else {
+        magmablas_zlaset( MagmaFull, dinvA_length, 1, MAGMA_Z_ZERO, MAGMA_Z_ZERO, d_dinvA, dinvA_length, queue );
+        magmablas_zlaset( MagmaFull, m, n, MAGMA_Z_ZERO, MAGMA_Z_ZERO, dX, lddx, queue );
+        magmablas_ztrsm_work_async( side, uplo, transA, diag, m, n, alpha,
+                                dA, ldda, dB, lddb, dX, lddx, 1, d_dinvA, dinvA_length, queue );
+    }
+
+    magma_free_async( d_dinvA, queue );
+    magma_free_async( dX, queue );
 }

--- a/magmablas/ztrtri_diag.cu
+++ b/magmablas/ztrtri_diag.cu
@@ -178,3 +178,105 @@ magmablas_ztrtri_diag(
         }
     }
 }
+
+extern "C" void
+magmablas_ztrtri_diag_async(
+    magma_uplo_t uplo, magma_diag_t diag, magma_int_t n,
+    magmaDoubleComplex_const_ptr dA, magma_int_t ldda,
+    magmaDoubleComplex_ptr d_dinvA,
+    magma_queue_t queue)
+{
+    magma_int_t info = 0;
+    if (uplo != MagmaLower && uplo != MagmaUpper)
+        info = -1;
+    else if (diag != MagmaNonUnit && diag != MagmaUnit)
+        info = -2;
+    else if (n < 0)
+        info = -3;
+    else if (ldda < n)
+        info = -5;
+
+    if (info != 0) {
+        magma_xerbla( __func__, -(info) );
+        return;  //info
+    }
+
+    const int nblocks = magma_ceildiv( n, IB );
+
+    cudaMemsetAsync( d_dinvA, 0, magma_roundup( n, NB )*NB * sizeof(magmaDoubleComplex), queue->cuda_stream() );
+
+    if ( uplo == MagmaLower ) {
+        // invert diagonal IB x IB inner blocks
+        ztrtri_diag_lower_kernel
+            <<< nblocks, IB, 0, queue->cuda_stream() >>>
+            ( diag, n, dA, ldda, d_dinvA );
+
+        // build up NB x NB blocks (assuming IB=16 here):
+        // use   16 x 16  blocks to build  32 x 32  blocks,  1 x (1 x npages) grid,  4 x 4 threads;
+        // then  32 x 32  blocks to build  64 x 64  blocks,  1 x (2 x npages) grid,  8 x 4 threads;
+        // then  64 x 64  blocks to build 128 x 128 blocks,  1 x (4 x npages) grid, 16 x 4 threads;
+        // then 128 x 128 blocks to build 256 x 256 blocks,  2 x (8 x npages) grid, 16 x 4 threads.
+        for( int jb=IB; jb < NB; jb *= 2 ) {
+            const int kb = jb*2;
+            const int npages = magma_ceildiv( n, kb );
+            const dim3 threads( (jb <= 32 ? jb/4 : 16), 4 );
+            const dim3 grid( jb/(threads.x*threads.y), npages*(jb/16) );  // emulate 3D grid: NX * (NY*npages), for CUDA ARCH 1.x
+
+            //printf( "n %d, jb %d, grid %d x %d (%d x %d)\n", n, jb, grid.x, grid.y, grid.y / npages, npages );
+            switch (jb) {
+                case 16:
+                    triple_zgemm16_part1_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm16_part2_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                case 32:
+                    triple_zgemm32_part1_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm32_part2_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                case 64:
+                    triple_zgemm64_part1_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm64_part2_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                default:
+                    triple_zgemm_above64_part1_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm_above64_part2_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm_above64_part3_lower_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+            }
+            if ( kb >= n ) break;
+        }
+    }
+    else {
+        ztrtri_diag_upper_kernel
+            <<< nblocks, IB, 0, queue->cuda_stream() >>>
+            ( diag, n, dA, ldda, d_dinvA );
+
+        // update the inverse up to the size of IB
+        for( int jb=IB; jb < NB; jb *= 2 ) {
+            const int kb = jb*2;
+            const int npages = magma_ceildiv( n, kb );
+            const dim3 threads( (jb <= 32 ? jb/4 : 16), 4 );
+            const dim3 grid( jb/(threads.x*threads.y), npages*(jb/16) );  // emulate 3D grid: NX * (NY*npages), for CUDA ARCH 1.x
+
+            switch (jb) {
+                case 16:
+                    triple_zgemm16_part1_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm16_part2_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                case 32:
+                    triple_zgemm32_part1_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm32_part2_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                case 64:
+                    triple_zgemm64_part1_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm64_part2_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+                default:
+                    triple_zgemm_above64_part1_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm_above64_part2_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    triple_zgemm_above64_part3_upper_kernel<<< grid, threads, 0, queue->cuda_stream() >>>( n, dA, ldda, d_dinvA, jb, npages );
+                    break;
+            }
+            if ( kb >= n ) break;
+        }
+    }
+}

--- a/src/zgetrf_nopiv_gpu.cpp
+++ b/src/zgetrf_nopiv_gpu.cpp
@@ -209,3 +209,153 @@ magma_zgetrf_nopiv_gpu(
     
     return *info;
 } /* magma_zgetrf_nopiv_gpu */
+
+extern "C" magma_int_t
+magma_zgetrf_nopiv_gpu_async(
+        magma_int_t m, magma_int_t n,
+        magmaDoubleComplex_ptr dA, magma_int_t ldda,
+        magma_int_t *info,
+        magma_queue_t queue)
+{
+#ifdef MAGMA_HAVE_OPENCL
+#define  dA(i_, j_) dA,  (dA_offset  + (i_)*nb       + (j_)*nb*ldda)
+#else
+#define  dA(i_, j_) (dA  + (i_)*nb       + (j_)*nb*ldda)
+#endif
+
+    const magmaDoubleComplex c_one     = MAGMA_Z_ONE;
+    const magmaDoubleComplex c_neg_one = MAGMA_Z_NEG_ONE;
+
+    magma_int_t iinfo, nb;
+    magma_int_t maxm, mindim;
+    magma_int_t j, rows, s, ldwork;
+    magmaDoubleComplex *work;
+
+    /* Check arguments */
+    *info = 0;
+    if (m < 0)
+        *info = -1;
+    else if (n < 0)
+        *info = -2;
+    else if (ldda < max(1,m))
+        *info = -4;
+
+    if (*info != 0) {
+        magma_xerbla( __func__, -(*info) );
+        return *info;
+    }
+
+    /* Quick return if possible */
+    if (m == 0 || n == 0)
+        return *info;
+
+    /* Function Body */
+    mindim = min( m, n );
+    nb     = magma_get_zgetrf_nb( m, n );
+    s      = mindim / nb;
+
+    magma_queue_t queues[2];
+    queues[0] = queue;
+    magma_queue_create( queue->device(), &queues[1] );
+
+    if (nb <= 1 || nb >= min(m,n)) {
+        /* Use CPU code. */
+        if ( MAGMA_SUCCESS != magma_zmalloc_cpu( &work, m*n )) {
+            *info = MAGMA_ERR_HOST_ALLOC;
+            return *info;
+        }
+        magma_zgetmatrix( m, n, dA(0,0), ldda, work, m, queues[0] );
+        magma_zgetrf_nopiv( m, n, work, m, info );
+        magma_zsetmatrix( m, n, work, m, dA(0,0), ldda, queues[0] );
+        magma_free_cpu( work );
+    }
+    else {
+        /* Use hybrid blocked code. */
+        maxm = magma_roundup( m, 32 );
+
+        ldwork = maxm;
+        if (MAGMA_SUCCESS != magma_zmalloc_pinned( &work, ldwork*nb )) {
+            *info = MAGMA_ERR_HOST_ALLOC;
+            return *info;
+        }
+
+        for( j=0; j < s; j++ ) {
+            // get j-th panel from device
+            magma_queue_sync( queues[1] );
+            magma_zgetmatrix_async( m-j*nb, nb, dA(j,j), ldda, work, ldwork, queues[0] );
+
+            if ( j > 0 ) {
+                magma_ztrsm( MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+                             nb, n - (j+1)*nb,
+                             c_one, dA(j-1,j-1), ldda,
+                             dA(j-1,j+1), ldda, queues[1] );
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans,
+                             m-j*nb, n-(j+1)*nb, nb,
+                             c_neg_one, dA(j,  j-1), ldda,
+                             dA(j-1,j+1), ldda,
+                             c_one,     dA(j,  j+1), ldda, queues[1] );
+            }
+
+            // do the cpu part
+            rows = m - j*nb;
+            magma_queue_sync( queues[0] );
+            magma_zgetrf_nopiv( rows, nb, work, ldwork, &iinfo );
+            if ( *info == 0 && iinfo > 0 )
+                *info = iinfo + j*nb;
+
+            // send j-th panel to device
+            magma_zsetmatrix_async( m-j*nb, nb, work, ldwork, dA(j, j), ldda, queues[1] );
+
+            // do the small non-parallel computations (next panel update)
+            if ( s > j+1 ) {
+                magma_ztrsm( MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+                             nb, nb,
+                             c_one, dA(j, j), ldda,
+                             dA(j, j+1), ldda, queues[1] );
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans,
+                             m-(j+1)*nb, nb, nb,
+                             c_neg_one, dA(j+1, j), ldda,
+                             dA(j,   j+1), ldda,
+                             c_one,     dA(j+1, j+1), ldda, queues[1] );
+            }
+            else {
+                magma_ztrsm( MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+                             nb, n-s*nb,
+                             c_one, dA(j, j  ), ldda,
+                             dA(j, j+1), ldda, queues[1] );
+                magma_zgemm( MagmaNoTrans, MagmaNoTrans,
+                             m-(j+1)*nb, n-(j+1)*nb, nb,
+                             c_neg_one, dA(j+1, j  ), ldda,
+                             dA(j,   j+1), ldda,
+                             c_one,     dA(j+1, j+1), ldda, queues[1] );
+            }
+        }
+
+        magma_int_t nb0 = min( m - s*nb, n - s*nb );
+        if ( nb0 > 0 ) {
+            rows = m - s*nb;
+
+            magma_zgetmatrix( rows, nb0, dA(s,s), ldda, work, ldwork, queues[1] );
+
+            // do the cpu part
+            magma_zgetrf_nopiv( rows, nb0, work, ldwork, &iinfo );
+            if ( *info == 0 && iinfo > 0 )
+                *info = iinfo + s*nb;
+
+            // send j-th panel to device
+            magma_zsetmatrix( rows, nb0, work, ldwork, dA(s,s), ldda, queues[1] );
+
+            magmablas_ztrsm_async( MagmaLeft, MagmaLower, MagmaNoTrans, MagmaUnit,
+                         nb0, n-s*nb-nb0,
+                         c_one, dA(s,s),     ldda,
+                         dA(s,s)+nb0, ldda, queues[1] );
+        }
+        magma_queue_sync( queues[1] );
+
+        magma_free_pinned( work );
+    }
+
+    magma_queue_destroy( queues[1] );
+
+    return *info;
+} /* magma_zgetrf_nopiv_gpu_async */


### PR DESCRIPTION
This pull request introduces two solver functions using GESV RBT:

```
magma_int_t
magma_zgesv_rbt_async(
        const magma_bool_t refine, const magma_int_t n, const magma_int_t nrhs,
        const magmaDoubleComplex *const dA_, const magma_int_t lda,
        magmaDoubleComplex *const dB_, const magma_int_t ldb,
        magma_int_t *const info,
        const magma_int_t iter_max, const double bwdmax,
        magma_queue_t queue)

magma_int_t
magma_zgesv_rbt_refine_async(
        const magma_int_t n, const magma_int_t nrhs,
        const magmaDoubleComplex *const dA_, const magma_int_t lda,
        magmaDoubleComplex *const dB_, const magma_int_t ldb,
        magma_int_t *info,
        const magma_int_t iter_max, const double bwdmax,
        magma_queue_t queue)
```

As you can see they introduce 3 new parameters 
- **iter_max** - maximum number of refinement iterations
- **bwdmax** - refinement threshold (error above this threshold will cause more refinement iterations up until iter_max is reached)
- **queue** - an already constructed MAGMA queue, that can be reused further in order to avoid spending cycle on initializing and uninitializing a new queue every time the function is called.

I wrote this function in order to speed up the tuning of support vector regression parameters where I find it perform better than the rest of solvers present in MAGMA. This version has a slightly better accuracy since it saves the best solution from all iterations, instead of using the last iteration solution. The fact that it uses async functions internally and an already initialized queue saved me about 30% of measure time when called over the process of tuning parameters, in the magnitude of 3000 to 10000 calls on a Dell R730 with 4xV100 Nvidia cards. It can use a specific CUDA stream created by the user since it take a **magma_queue_t** as an argument.
I haven't written unit tests for these methods but they should be similar to the old **magma_zgesv_rbt** function. I tested the accuracy of this implementation in my project, Tempus.