### PR TITLE
Restore sync in order to avoid memory issue

### DIFF
--- a/src/zpotrs_batched.cpp
+++ b/src/zpotrs_batched.cpp
@@ -162,5 +162,8 @@ magma_zpotrs_batched(
                 dB_array,    1, batchCount, queue );
         }
     }
+
+    magma_queue_sync(queue);
+
     return info;
 }


### PR DESCRIPTION
Sync was removed in fa9340a1b255ae992498f610837e7021798acfca

Affects next pytorch UT:
1. TestCommonCUDA.test_out_cholesky_solve_cuda_float32
1. TestMathBitsCUDA.test_conj_view_cholesky_solve_cuda_complex64
1. TestCommonCUDA.test_noncontiguous_samples_cholesky_solve_cuda_float32
1. TestCommonCUDA.test_noncontiguous_samples_cholesky_inverse_cuda_float32
1. TestCommonCUDA.test_noncontiguous_samples_cholesky_inverse_cuda_complex64
1. TestMathBitsCUDA.test_neg_view_cholesky_inverse_cuda_float64

One of pytorch UT cases for verification:
```
#!/bin/bash

export PYTORCH_TEST_WITH_ROCM=1
COMMAND="python test/test_ops.py -v TestCommonCUDA.test_out_cholesky_solve_cuda_float32"
RUN_COUNT=0

while true; do
    RUN_COUNT=$((RUN_COUNT + 1))

    echo "Run #$RUN_COUNT: Running command: $COMMAND"
    $COMMAND
    EXIT_CODE=$?

    if [ $EXIT_CODE -ne 0 ]; then
        echo "Command failed on run #$RUN_COUNT with exit code $EXIT_CODE. Exiting loop."
        break
    fi
done
```