### PR TITLE
Add MAGMA_BLAS_PREFIX for prefixed BLAS/LAPACK symbols

### DIFF
--- a/include/magma_mangling.h
+++ b/include/magma_mangling.h
@@ -19,15 +19,32 @@
  *   include/magma_*lapack.h
  *   control/magma_*f77.cpp
  */
+/* Optional BLAS symbol prefix (e.g. -DMAGMA_BLAS_PREFIX=openblas_).
+ * Two levels of indirection so the prefix macro is expanded before pasting. */
+#define _MAGMA_PASTE(a, b)  a ## b
+#define _MAGMA_EXPAND(a, b) _MAGMA_PASTE(a, b)
+
 #ifndef MAGMA_FORTRAN_NAME
     #if defined(MAGMA_GLOBAL)
         #define FORTRAN_NAME(lcname, UCNAME)  MAGMA_GLOBAL( lcname, UCNAME )
     #elif defined(ADD_)
-        #define FORTRAN_NAME(lcname, UCNAME)  lcname##_
+        #ifdef MAGMA_BLAS_PREFIX
+            #define FORTRAN_NAME(lcname, UCNAME)  _MAGMA_EXPAND(MAGMA_BLAS_PREFIX, lcname##_)
+        #else
+            #define FORTRAN_NAME(lcname, UCNAME)  lcname##_
+        #endif
     #elif defined(NOCHANGE)
-        #define FORTRAN_NAME(lcname, UCNAME)  lcname
+        #ifdef MAGMA_BLAS_PREFIX
+            #define FORTRAN_NAME(lcname, UCNAME)  _MAGMA_EXPAND(MAGMA_BLAS_PREFIX, lcname)
+        #else
+            #define FORTRAN_NAME(lcname, UCNAME)  lcname
+        #endif
     #elif defined(UPCASE)
-        #define FORTRAN_NAME(lcname, UCNAME)  UCNAME
+        #ifdef MAGMA_BLAS_PREFIX
+            #define FORTRAN_NAME(lcname, UCNAME)  _MAGMA_EXPAND(MAGMA_BLAS_PREFIX, UCNAME)
+        #else
+            #define FORTRAN_NAME(lcname, UCNAME)  UCNAME
+        #endif
     #else
         #error "One of ADD_, NOCHANGE, or UPCASE must be defined to set how Fortran functions are name mangled. For example, in MAGMA, add -DADD_ to CFLAGS, FFLAGS, etc. in make.inc. If using CMake, it defines MAGMA_GLOBAL instead."
         #define FORTRAN_NAME(lcname, UCNAME)  lcname##_error


### PR DESCRIPTION
## Summary
- Adds optional `MAGMA_BLAS_PREFIX` macro to `magma_mangling.h`
- When defined (e.g. `-DMAGMA_BLAS_PREFIX=openblas_`), all BLAS/LAPACK symbols are prefixed accordingly (`dgemm_` → `openblas_dgemm_`)
- Useful when linking against OpenBLAS builds that use `SYMBOLPREFIX`
- No change in behavior when `MAGMA_BLAS_PREFIX` is not defined

## Test plan
- [x] Verified macro expansion: `FORTRAN_NAME(dgemm, DGEMM)` → `openblas_dgemm_`
- [x] Clean build and all testers link successfully
- [x] Numerical tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)